### PR TITLE
Make sure search request options are passed through.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/searching.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/searching.rb
@@ -95,7 +95,7 @@ module Elasticsearch
         #     Article.search '{"query" : { "match_all" : {} }}'
         #
         def search(query_or_payload, options={})
-          search   = SearchRequest.new(self, query_or_payload, options={})
+          search   = SearchRequest.new(self, query_or_payload, options)
 
           Response::Response.new(self, search)
         end

--- a/elasticsearch-model/test/unit/searching_test.rb
+++ b/elasticsearch-model/test/unit/searching_test.rb
@@ -23,10 +23,11 @@ class Elasticsearch::Model::SearchingTest < Test::Unit::TestCase
         .expects(:new).with do |klass, query, options|
           assert_equal DummySearchingModel, klass
           assert_equal 'foo', query
+          assert_equal({default_operator: 'AND'}, options)
         end
         .returns( stub('search') )
 
-      DummySearchingModel.search 'foo'
+      DummySearchingModel.search 'foo', default_operator: 'AND'
     end
 
     should "not execute the search" do


### PR DESCRIPTION
I think these options are meant to be passed on, not silently ignored. 

I discovered this while trying to perform a multi-index search while retaining the niceities of the Response/Results/Result wrapping by doing something like this:

``` ruby
Foo.search({query: ...}, index: [Foo.index_name, Bar.index_name].join(','))
```

(more or less what I used `Tire.search` for before)

However since the options are not being passed on I'm unable to update the `index` field.
