### PR TITLE
Use the read-only URL for the git repo paths

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -130,9 +130,9 @@ puts
 say_status  "Rubygems", "Adding Elasticsearch libraries into Gemfile...\n", :yellow
 puts        '-'*80, ''; sleep 0.75
 
-gem 'elasticsearch',       git: 'git@github.com:elasticsearch/elasticsearch-ruby.git'
-gem 'elasticsearch-model', git: 'git@github.com:elasticsearch/elasticsearch-rails.git'
-gem 'elasticsearch-rails', git: 'git@github.com:elasticsearch/elasticsearch-rails.git'
+gem 'elasticsearch',       git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'
+gem 'elasticsearch-model', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
+gem 'elasticsearch-rails', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
 
 # ----- Install gems ------------------------------------------------------------------------------
 


### PR DESCRIPTION
The original git paths required authentication and it was failing with a permission denied error.
