### PR TITLE
Bundler is not happy with es-model gemspec

### DIFF
--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "elasticsearch-extensions"
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "activesupport", "> 3.0"
   s.add_development_dependency "activemodel",   "> 3.0"
   s.add_development_dependency "activerecord",  "> 4.0"
 


### PR DESCRIPTION
When installing elasticsearch-model from the git repository, bundler says:

```
elasticsearch-model at /home/nono/.gem/ruby/2.1.0/bundler/gems/elasticsearch-rails-fc966380167b/elasticsearch-model did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on activesupport (> 3.0, development), (> 3) use:
    add_runtime_dependency 'activesupport', '> 3.0', '> 3'
```
