### PR TITLE
Don't fail when ansi/progressbar is not installed

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -15,7 +15,10 @@
 STDOUT.sync = true
 STDERR.sync = true
 
-begin; require 'ansi/progressbar' rescue LoadError; end
+begin
+  require 'ansi/progressbar'
+rescue LoadError
+end
 
 namespace :elasticsearch do
 


### PR DESCRIPTION
When the gem ansi/progressbar is not installed, running rake tasks fails with:

```
rake aborted!
cannot load such file -- ansi/progressbar
```
