### PR TITLE
Re-enable import:model after each invocation in import:all

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -96,6 +96,7 @@ namespace :elasticsearch do
 
         ENV['CLASS'] = klass.to_s
         Rake::Task["elasticsearch:import:model"].invoke
+        Rake::Task["elasticsearch:import:model"].reenable
         puts
       end
     end


### PR DESCRIPTION
The elasticsearch:import:all task was only importing the first class that it attempted to import, rather than actually importing all.

Rake::Task#invoke only executes the task if it has not been invoked already, so by doing so in a loop, it only  actually gets invoked once. This pull request fixes this by calling Rake::Task#reenable after each invocation so that it can be invoked again in future iterations and import:all actually imports all.
