### PR TITLE
Elasticsearch::Model::Adapter::ActiveRecord not ensuring order in some cases

### DIFF
--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -123,6 +123,15 @@ module Elasticsearch
           assert_equal 'Test', response.records.where(title: 'Test').first.title
         end
 
+        should "preserve ordering when chaining SQL commands on response.records" do
+          response = Article.search query: { match: { title: { query: 'test' } } }, sort: {_score: 'asc'}
+ 
+          assert_equal 'Testing Coding', Article.find(response.results.first._id).title
+          assert_equal 'Testing Coding', response.records.where('1=1').first.title
+        end
+ 
+
+
         should "allow ordering response.records in SQL" do
           response = Article.search query: { match: { title: { query: 'test' } } }
 


### PR DESCRIPTION
The adapter adds an order singleton method that in effect removes the special version of to_a added earlier. 
However, calling first and last adds an explicit order by primary key, so when calling these methods we always throw away the elastic search generated ordering

I've attached a failing test for this.

The where('1=1') is importing here (anything like joins, includes, etc.) would do: without it the implementation of first that is called is the one from Enumerable, rather than calling first on the relation

I also noticed that some of the [finder methods](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/finder_methods.rb#L460) operate on `@records` directly if it is loaded - there could be some edge cases here.

Not sure what the best way forward is. One way would be to make this a true relation by doing something like `.order("fields(#{klass.primary_key},1,2,3")` so that then the relation is just a normal relation. Or perhaps what `records` requires is just a bit too clever and makes too much use of AR internals
