### PR TITLE
Fix in expert template, missing equal sign

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/03-expert.rb
+++ b/elasticsearch-rails/lib/rails/templates/03-expert.rb
@@ -82,7 +82,7 @@ if Rails.env.development?
   tracer.level =  Logger::INFO
 end
 
-Elasticsearch::Model.client Elasticsearch::Client.new tracer: tracer, host: ELASTICSEARCH_URL
+Elasticsearch::Model.client = Elasticsearch::Client.new tracer: tracer, host: ELASTICSEARCH_URL
 CODE
 
 git :add    => 'config/initializers'


### PR DESCRIPTION
code snippet from model:

```
  def client
    @client ||= Elasticsearch::Client.new
  end

  def client=(client)
    @client = client
  end
```
