### PR TITLE
`rake elasticsearch:import:model` prints errors

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -56,16 +56,17 @@ namespace :elasticsearch do
         rescue NoMethodError; end
       end
 
-      klass.import force:      ENV.fetch('FORCE', false),
-                   batch_size: ENV.fetch('BATCH', 1000).to_i,
-                   index:      ENV.fetch('INDEX', nil),
-                   type:       ENV.fetch('TYPE',  nil) do |response|
+      total_errors = klass.import force: ENV.fetch('FORCE', false),
+                                  batch_size: ENV.fetch('BATCH', 1000).to_i,
+                                  index:      ENV.fetch('INDEX', nil),
+                                  type:       ENV.fetch('TYPE',  nil) do |response|
         pbar.inc response['items'].size if pbar
         STDERR.flush
         STDOUT.flush
       end
       pbar.finish if pbar
 
+      puts "[IMPORT] #{total_errors} errors occurred" unless total_errors.zero?
       puts '[IMPORT] Done'
     end
 


### PR DESCRIPTION
Prior to this pull-request, these errors would be silently ignored. This caused me some confusion, since when I saw `[IMPORT] Done` I assumed that the task had completed successfully. Now the number of errors is printed:

```
$ bundle exec rake environment elasticsearch:import:model CLASS=User
[IMPORT] 4 errors occurred
[IMPORT] Done
```

It would be nice to have more details about the errors (I can submit another PR later). But this is an improvement over failing silently.
