### PR TITLE
kaminari divided by 0 error

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/searching.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/searching.rb
@@ -24,7 +24,7 @@ module Elasticsearch
           case
             # search query: ...
             when query_or_payload.respond_to?(:to_hash)
-              body = query_or_payload.to_hash
+              body = query_or_payload.to_hash.deep_symbolize_keys
 
             # search '{ "query" : ... }'
             when query_or_payload.is_a?(String) && query_or_payload =~ /^\s*{/

--- a/elasticsearch-model/test/unit/response_pagination_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_test.rb
@@ -81,6 +81,19 @@ class Elasticsearch::Model::ResponsePaginationTest < Test::Unit::TestCase
         assert_equal 50, @response.limit_value
         assert_equal 10, @response.offset_value
       end
+
+      should "return the value from body with object responding to `to_hash`" do
+        query = Hashie::Mash.new({
+          query: { match_all: {} },
+          size:  50,
+          from:  10
+        })
+        search    = Elasticsearch::Model::Searching::SearchRequest.new ModelClass, query
+        @response = Elasticsearch::Model::Response::Response.new ModelClass, search, RESPONSE
+
+        assert_equal 50, @response.limit_value
+        assert_equal 10, @response.offset_value
+      end
     end
 
     context "limit setter" do


### PR DESCRIPTION
When I try to use Hashie::Mash search query I get "divided by 0" error in kaminari paginate method
