### PR TITLE
Refactored Response::Result

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -4,46 +4,65 @@ module Elasticsearch
 
       # Encapsulates the "hit" returned from the Elasticsearch client
       #
-      # Wraps the raw Hash with in a `Hashie::Mash` instance, providing
-      # access to the Hash properties by calling Ruby methods.
+      # Wraps the _source and highlight values in a `Hashie::Mash` instance,
+      # providing access to those properties by calling Ruby methods.
       #
       # @see https://github.com/intridea/hashie
       #
       class Result
+        attr_reader :attributes
 
         # @param attributes [Hash] A Hash with document properties
         #
         def initialize(attributes={})
-          @result = Hashie::Mash.new(attributes)
+          @attributes = attributes
         end
 
-        # Delegate methods to `@result` or `@result._source`
+        def _source
+          @_source ||= (Hashie::Mash.new(@attributes['_source']) if @attributes['_source'])
+        end
+
+        def _source?
+          !!_source
+        end
+
+        def highlight
+          @highlight ||= (Hashie::Mash.new(@attributes['highlight']) if @attributes['highlight'])
+        end
+
+        def highlight?
+          !!highlight
+        end
+
+        # Delegate methods to `@attributes` or `self._source`
         #
         def method_missing(method_name, *arguments)
-          case
-          when @result.respond_to?(method_name.to_sym)
-            @result.__send__ method_name.to_sym, *arguments
-          when @result._source && @result._source.respond_to?(method_name.to_sym)
-            @result._source.__send__ method_name.to_sym, *arguments
+          if @attributes[method_name.to_s]
+            @attributes[method_name.to_s]
+          elsif _source.respond_to?(method_name)
+            _source.send(method_name, *arguments)
           else
             super
           end
         end
 
-        # Respond to methods from `@result` or `@result._source`
+        # Respond to `@attributes` or `self._source`
         #
         def respond_to?(method_name, include_private = false)
-          @result.respond_to?(method_name.to_sym) || \
-          @result._source && @result._source.respond_to?(method_name.to_sym) || \
+          @attributes[method_name.to_s] ||
+          _source.respond_to?(method_name) ||
           super
         end
 
         def as_json(options={})
-          @result.as_json(options)
+          @attributes.as_json(options)
         end
 
-        # TODO: #to_s, #inspect, with support for Pry
+        def to_s
+          to_json
+        end
 
+        alias_method :inspect, :to_s
       end
     end
   end

--- a/elasticsearch-model/test/unit/response_result_test.rb
+++ b/elasticsearch-model/test/unit/response_result_test.rb
@@ -4,8 +4,6 @@ class Elasticsearch::Model::ResultTest < Test::Unit::TestCase
   context "Response result" do
 
     should "have method access to properties" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar', bar: { bam: 'baz' }
-
       assert_respond_to result, :foo
       assert_respond_to result, :bar
 
@@ -16,37 +14,85 @@ class Elasticsearch::Model::ResultTest < Test::Unit::TestCase
     end
 
     should "delegate method calls to `_source` when available" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _source: { bar: 'baz' }
-
       assert_respond_to result, :foo
       assert_respond_to result, :_source
       assert_respond_to result, :bar
 
       assert_equal 'bar', result.foo
-      assert_equal 'baz', result._source.bar
-      assert_equal 'baz', result.bar
-    end
+      assert_equal 'baz', result._source.bar.bam
+      assert_equal 'baz', result.bar.bam
 
-    should "delegate methods to @result" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar'
-
-      assert_equal 'bar', result.foo
       assert_equal 'bar', result.fetch('foo')
       assert_equal 'moo', result.fetch('NOT_EXIST', 'moo')
+    end
 
+    should "delegate existence method calls to `_source`" do
+      assert_respond_to result, :bar?
+      assert_respond_to result._source, :bar?
+
+      assert_equal true, result._source.bar?
+      assert_equal true, result.bar?
+      assert_equal false, result.baz?
+
+      assert_equal true, result.bar.bam?
+      assert_equal false, result.bar.boo?
+    end
+
+    should "delegate methods to _source" do
       assert_respond_to result, :to_hash
-      assert_equal({'foo' => 'bar'}, result.to_hash)
+      assert_equal({'foo' => 'bar', 'bar' => {'bam' => 'baz'}}, result.to_hash)
 
       assert_raise(NoMethodError) { result.does_not_exist }
     end
 
+    should "respond to highlight" do
+      assert_respond_to result, :highlight
+      assert_respond_to result, :highlight?
+
+      assert_equal({"foo"=>["<em>bar</em>"]}, result.highlight)
+      assert_equal true, result.highlight?
+
+      no_highlight = Elasticsearch::Model::Response::Result.new({foo: 'bar'})
+      assert_equal nil, no_highlight.highlight
+      assert_equal false, no_highlight.highlight?
+    end
+
     should "delegate as_json to @result even when ActiveSupport changed half of Ruby" do
       require 'active_support/json/encoding'
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar'
+      result = Elasticsearch::Model::Response::Result.new(example_response)
 
-      result.instance_variable_get(:@result).expects(:as_json)
+      result.instance_variable_get(:@attributes).expects(:as_json)
       result.as_json(except: 'foo')
     end
 
+    should "have a working to_s method" do
+      assert_equal example_response, JSON.parse(result.to_s)
+    end
+
+    should "have a working inspect method" do
+      assert_equal example_response, JSON.parse(result.inspect)
+    end
+  end
+
+  def result
+    Elasticsearch::Model::Response::Result.new(example_response)
+  end
+
+  def example_response
+    {
+      "_index" => "foo_index",
+      "_type" => "foo",
+      "_id" => "1",
+      "_score" => 1.0,
+      "_source" => {
+        "foo" => "bar",
+        "bar" => {
+          "bam" => "baz"
+        }
+      },
+      "highlight" => {
+        "foo" => ["<em>bar</em>"]
+      }
+    }
   end
 end


### PR DESCRIPTION
An alternative solution to #41 and #64. Sorry for changing the test so much, but it seemed better to test something that more accurately reflected an Elasticsearch response.

---

This avoids polluting the top level of the result
object with Hashie::Mash, but still delegates to
`@result._source`

Previously, the Mash existence methods
(such as `@result.name?`) were being hijacked by
method_missing and always returned false.

This also preserves `@result.highlight?`.
