### PR TITLE
Compatibility with active record 3.0 and 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ jdk:
 
 env:
   - TEST_BUNDLE_GEMFILE=$PWD/elasticsearch/elasticsearch-rails/elasticsearch-model/gemfiles/3.0.gemfile
+  - TEST_BUNDLE_GEMFILE=$PWD/elasticsearch/elasticsearch-rails/elasticsearch-model/gemfiles/3.1.gemfile
+  - TEST_BUNDLE_GEMFILE=$PWD/elasticsearch/elasticsearch-rails/elasticsearch-model/gemfiles/3.2.gemfile
   - TEST_BUNDLE_GEMFILE=$PWD/elasticsearch/elasticsearch-rails/elasticsearch-model/gemfiles/4.0.gemfile
 
 services:

--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options      = [ "--charset=UTF-8" ]
 
   s.add_dependency "elasticsearch",       '> 0.4'
-  s.add_dependency "activesupport",       '> 3'
+  s.add_dependency "activesupport",       '>= 3'
   s.add_dependency "hashie"
 
   s.add_development_dependency "bundler", "~> 1.3"
@@ -31,8 +31,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "elasticsearch-extensions"
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "activemodel",   "> 3.0"
-  s.add_development_dependency "activerecord",  "> 4.0"
+  s.add_development_dependency "activemodel",   ">= 3"
+  s.add_development_dependency "activerecord",  ">= 3"
 
   s.add_development_dependency "oj"
   s.add_development_dependency "kaminari"

--- a/elasticsearch-model/gemfiles/3.0.gemfile
+++ b/elasticsearch-model/gemfiles/3.0.gemfile
@@ -7,6 +7,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel',  '>= 3.0'
-gem 'activerecord', '~> 3.2'
-gem 'mongoid',      '>= 3.0'
+gem 'activemodel',  '~> 3.0.0'
+gem 'activerecord', '~> 3.0.0'
+gem 'actionpack',   '~> 3.0.0'
+
+gem 'mongoid',      '~> 2.2.6'

--- a/elasticsearch-model/gemfiles/3.1.gemfile
+++ b/elasticsearch-model/gemfiles/3.1.gemfile
@@ -1,0 +1,14 @@
+# Usage:
+#
+# $ BUNDLE_GEMFILE=./gemfiles/3.1.gemfile bundle install
+# $ BUNDLE_GEMFILE=./gemfiles/3.1.gemfile bundle exec rake test:integration
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activemodel',  '~> 3.1.0'
+gem 'activerecord', '~> 3.1.0'
+gem 'actionpack',   '~> 3.1.0'
+
+gem 'mongoid',      '~> 2.5.2'

--- a/elasticsearch-model/gemfiles/3.2.gemfile
+++ b/elasticsearch-model/gemfiles/3.2.gemfile
@@ -1,0 +1,14 @@
+# Usage:
+#
+# $ BUNDLE_GEMFILE=./gemfiles/3.2.gemfile bundle install
+# $ BUNDLE_GEMFILE=./gemfiles/3.2.gemfile bundle exec rake test:integration
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activemodel',  '~> 3.2.0'
+gem 'activerecord', '~> 3.2.0'
+gem 'actionpack',   '~> 3.2.0'
+
+gem 'mongoid',      '~> 3.1.6'

--- a/elasticsearch-model/gemfiles/4.0.gemfile
+++ b/elasticsearch-model/gemfiles/4.0.gemfile
@@ -7,6 +7,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel',  '~> 4'
-gem 'activerecord', '~> 4'
+gem 'activemodel',  '~> 4.0'
+gem 'activerecord', '~> 4.0'
+gem 'actionpack',   '~> 4.0'
+
 gem 'mongoid',      '~> 4.0.0.beta1'

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -20,11 +20,7 @@ module Elasticsearch
             #
             sql_records.instance_exec(response.response['hits']['hits']) do |hits|
               define_singleton_method :to_a do
-                if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 4
-                  self.load
-                else
-                  self.__send__(:exec_queries)
-                end
+                super()
                 @records.sort_by { |record| hits.index { |hit| hit['_id'].to_s == record.id.to_s } }
               end
             end
@@ -47,11 +43,7 @@ module Elasticsearch
             #
             sql_records.instance_exec do
               define_singleton_method(:to_a) do
-                if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 4
-                  self.load
-                else
-                  self.__send__(:exec_queries)
-                end
+                super()
                 @records
               end
             end


### PR DESCRIPTION
Calling `super()` makes the active record adapter compatible with older versions of active record.