### PR TITLE
Return value of the id column is nil all the time

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -17,6 +17,18 @@ module Elasticsearch
           @result = Hashie::Mash.new(attributes)
         end
 
+        # Alias `id` to `_id`
+        #
+        def id
+          @result['_id']
+        end
+
+        # Alias `type` to `_type`
+        #
+        def type
+          @result['_type']
+        end
+
         # Delegate methods to `@result` or `@result._source`
         #
         def method_missing(name, *arguments)

--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -72,6 +72,13 @@ module Elasticsearch
           assert_equal [1, 2],     response.records.map(&:id)
         end
 
+        should "iterate aliased id and type over results" do
+          response = Article.search('title:test')
+
+          assert_equal ['1', '2'],             response.results.map(&:id)
+          assert_equal ['article', 'article'], response.results.map(&:type)
+        end
+
         should "access results from records" do
           response = Article.search('title:test')
 

--- a/elasticsearch-model/test/unit/response_result_test.rb
+++ b/elasticsearch-model/test/unit/response_result_test.rb
@@ -73,16 +73,16 @@ class Elasticsearch::Model::ResultTest < Test::Unit::TestCase
       result.as_json(except: 'foo')
     end
 
-    should "return nil for id if it is not present in source" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _source: { uuid: 'foo-baz' }
-
-      assert_equal nil, result.id
-    end
-
-    should "delegate id to source if source responds to id" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _source: { id: 42 }
+    should "map the _id column to id" do
+      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _id: 42
 
       assert_equal 42, result.id
+    end
+
+    should "map the _type column to type" do
+      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _type: 'baz'
+
+      assert_equal 'baz', result.type
     end
   end
 end


### PR DESCRIPTION
If the id column is present in the _source attributes it is not correctly mapped to the result.id because Hashie::Mash explicitly defines `id` and `type` columns [here](https://github.com/intridea/hashie/blob/master/lib/hashie/mash.rb#L73-L79)
So I have added an explicit mapping of the id column to `record._source` if it responds to it.
