### PR TITLE
broken tests for using each_with_hit and search result order

### DIFF
--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -81,13 +81,15 @@ module Elasticsearch
           end
         end
 
-        should "zip results from records" do
+        should "preserve the search results order for records" do
           response = Article.search('title:code')
 
           response.records.each_with_hit do |r, h|
-            assert_not_nil h._score
-            assert_not_nil h._source.title
             assert_equal h._id, r.id.to_s
+          end
+
+          response.records.map_with_hit do |r, h|
+            assert_equal h._id, r._id.to_s
           end
         end
 

--- a/elasticsearch-model/test/integration/mongoid_basic_test.rb
+++ b/elasticsearch-model/test/integration/mongoid_basic_test.rb
@@ -95,12 +95,14 @@ if ENV["MONGODB_AVAILABLE"]
             end
           end
 
-          should "zip results from records" do
+          should "preserve the search results order for records" do
             response = MongoidArticle.search('title:code')
 
             response.records.each_with_hit do |r, h|
-              assert_not_nil h._score
-              assert_not_nil h._source.title
+              assert_equal h._id, r._id.to_s
+            end
+
+            response.records.map_with_hit do |r, h|
               assert_equal h._id, r._id.to_s
             end
           end


### PR DESCRIPTION
broken tests for using each_with_hit when the returned records should not be the natural order.

this is for issue #99

searching for 'code' returns 'Coding' first and 'Test Coding' second from elasticsearch.
it compares ids of db records to response result.

note: calling to_a within the each_with_hit method changes the _id behavior on the mongoid record. it returned string id originally but after to_a is called, it returns ObjectId instead.
