### PR TITLE
[MODEL] add option to .import method to return the error messages instead of just the count

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -70,9 +70,9 @@ module Elasticsearch
         #
         def import(options={}, &block)
           errors         = []
-          refresh        = options.delete(:refresh) || false
-          target_index   = options.delete(:index)   || index_name
-          target_type    = options.delete(:type)    || document_type
+          refresh        = options.delete(:refresh)       || false
+          target_index   = options.delete(:index)         || index_name
+          target_type    = options.delete(:type)          || document_type
           return_errors  = options.delete(:return_errors) || false
 
           if options.delete(:force)
@@ -87,14 +87,16 @@ module Elasticsearch
 
             yield response if block_given?
 
-            errors.concat(response['items'].map { |k, v| k.values.first['error'] })
+            errors += response['items'].select { |i| i['index']['error'] }
           end
 
           self.refresh_index! if refresh
 
-          errors.compact!
-
-          return return_errors ? errors : errors.size
+          if return_errors
+            errors
+          else
+            errors.size
+          end
         end
 
       end

--- a/elasticsearch-model/test/unit/importing_test.rb
+++ b/elasticsearch-model/test/unit/importing_test.rb
@@ -77,7 +77,9 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       DummyImportingModel.stubs(:index_name).returns('foo')
       DummyImportingModel.stubs(:document_type).returns('foo')
 
-      assert_equal [error_text], DummyImportingModel.import(return_errors: true)
+      expected_error_element = {'index' => {'error' => error_text}}
+
+      assert_equal [expected_error_element], DummyImportingModel.import(return_errors: true)
     end
 
     should "yield the response" do


### PR DESCRIPTION
optional parameter to model_class.import method to return the list of errors instead of just the count of them, for logging and debugging purposes.
