### PR TITLE
Coerce pagination string params

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -66,6 +66,7 @@ module Elasticsearch
           # Set the "limit" (`size`) value
           #
           def limit(value)
+            return if value.to_i <= 0
             @results  = nil
             @records  = nil
             @response = nil
@@ -79,6 +80,7 @@ module Elasticsearch
           # Set the "offset" (`from`) value
           #
           def offset(value)
+            return if value.to_i <= 0
             @results  = nil
             @records  = nil
             @response = nil

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -66,7 +66,7 @@ module Elasticsearch
           # Set the "limit" (`size`) value
           #
           def limit(value)
-            return if value.to_i <= 0
+            return self if value.to_i <= 0
             @results  = nil
             @records  = nil
             @response = nil
@@ -80,7 +80,7 @@ module Elasticsearch
           # Set the "offset" (`from`) value
           #
           def offset(value)
-            return if value.to_i <= 0
+            return self if value.to_i < 0
             @results  = nil
             @records  = nil
             @response = nil

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -69,7 +69,7 @@ module Elasticsearch
             @results  = nil
             @records  = nil
             @response = nil
-            @per_page = value
+            @per_page = value.to_i
 
             search.definition.update :size => @per_page
             search.definition.update :from => @per_page * (@page - 1) if @page
@@ -83,7 +83,7 @@ module Elasticsearch
             @records  = nil
             @response = nil
             @page     = nil
-            search.definition.update :from => value
+            search.definition.update :from => value.to_i
             self
           end
 

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -168,10 +168,10 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         assert_equal 35, @response.search.definition[:from]
       end
 
-      should 'ignore invalid string parameters' do
+      should 'coerce invalid string parameters' do
         @response.offset(35)
         @response.offset("asdf")
-        assert_equal 35, @response.search.definition[:from]
+        assert_equal 0, @response.search.definition[:from]
       end
     end
 

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -104,6 +104,11 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         assert_nil @response.instance_variable_get(:@records)
         assert_nil @response.instance_variable_get(:@results)
       end
+
+      should 'coerce string parameters' do
+        @response.limit("35")
+        assert_equal 35, @response.search.definition[:size]
+      end
     end
 
     context "with the page() and limit() methods" do
@@ -150,6 +155,11 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         assert_nil @response.instance_variable_get(:@response)
         assert_nil @response.instance_variable_get(:@records)
         assert_nil @response.instance_variable_get(:@results)
+      end
+
+      should 'coerce string parameters' do
+        @response.offset("35")
+        assert_equal 35, @response.search.definition[:from]
       end
     end
 

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -109,6 +109,12 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         @response.limit("35")
         assert_equal 35, @response.search.definition[:size]
       end
+
+      should 'ignore invalid string parameters' do
+        @response.limit(35)
+        @response.limit("asdf")
+        assert_equal 35, @response.search.definition[:size]
+      end
     end
 
     context "with the page() and limit() methods" do
@@ -159,6 +165,12 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
 
       should 'coerce string parameters' do
         @response.offset("35")
+        assert_equal 35, @response.search.definition[:from]
+      end
+
+      should 'ignore invalid string parameters' do
+        @response.offset(35)
+        @response.offset("asdf")
         assert_equal 35, @response.search.definition[:from]
       end
     end


### PR DESCRIPTION
We hit this in our app when we pass in params from a rails controller.  This PR causes the `limit` and `offset` methods to work like the `page` (or `::Kaminari.config.page_method_name`) method already does.