### PR TITLE
Allow parent to be defined when importing a given class.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -68,6 +68,10 @@ module Elasticsearch
         #
         #    Article.import scope: 'published'
         #
+        # @example Import documents that are parent aware:
+        #
+        #    Article.import parent: 'author_id'
+        #
         def import(options={}, &block)
           errors       = 0
           refresh      = options.delete(:refresh) || false

--- a/elasticsearch-model/test/unit/adapter_active_record_test.rb
+++ b/elasticsearch-model/test/unit/adapter_active_record_test.rb
@@ -104,6 +104,18 @@ class Elasticsearch::Model::AdapterActiveRecordTest < Test::Unit::TestCase
         DummyClassForActiveRecord.__find_in_batches(scope: :published) do; end
       end
 
+      should "add parent identifier to the batch item" do
+        model = mock('model', id: 1, parent_id: 10, __elasticsearch__: stub(as_indexed_json: {}))
+        DummyClassForActiveRecord.expects(:find_in_batches).yields([model])
+
+        DummyClassForActiveRecord.__find_in_batches(parent: :parent_id) do; end
+      end
+
+      should "raise an exception when passing an invalid method" do
+        assert_raise NoMethodError do
+          DummyClassForActiveRecord.__find_in_batches(parent: :not_found_method) do; end
+        end
+      end
     end
   end
 end

--- a/elasticsearch-rails/README.md
+++ b/elasticsearch-rails/README.md
@@ -48,6 +48,13 @@ pass it to the task:
 $ bundle exec rake environment elasticsearch:import:model CLASS='Article' SCOPE='published'
 ```
 
+To specify the [parent document](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-parent-field.html) of your model, pass the method name:
+
+```bash
+$ bundle exec rake environment elasticsearch:import:model CLASS='Article' PARENT='author_id'
+```
+
+
 Run this command to display usage instructions:
 
 ```bash

--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -38,6 +38,9 @@ namespace :elasticsearch do
 
       Pass an ActiveRecord scope to limit the imported records:
         $ rake environment elasticsearch:import:model CLASS='Article' SCOPE='published'
+
+      Pass an ActiveRecord method that identifies the parent document:
+        $ rake environment elasticsearch:import:model CLASS='Article' PARENT='author_id'
     DESC
     task :model do
       if ENV['CLASS'].to_s == ''
@@ -59,11 +62,12 @@ namespace :elasticsearch do
         rescue NoMethodError; end
       end
 
-      total_errors = klass.import force:      ENV.fetch('FORCE', false),
-                                  batch_size: ENV.fetch('BATCH', 1000).to_i,
-                                  index:      ENV.fetch('INDEX', nil),
-                                  type:       ENV.fetch('TYPE',  nil),
-                                  scope:      ENV.fetch('SCOPE', nil) do |response|
+      total_errors = klass.import force:      ENV.fetch('FORCE',  false),
+                                  batch_size: ENV.fetch('BATCH',  1000).to_i,
+                                  index:      ENV.fetch('INDEX',  nil),
+                                  type:       ENV.fetch('TYPE',   nil),
+                                  parent:     ENV.fetch('PARENT', nil),
+                                  scope:      ENV.fetch('SCOPE',  nil) do |response|
         pbar.inc response['items'].size if pbar
         STDERR.flush
         STDOUT.flush


### PR DESCRIPTION
This allows the `#import` method to specify the parent document.

``` ruby
class Article
  belongs_to :author
end
```

``` ruby
Article.import parent: 'author_id'
```

``` bash
bundle exec rake environment elasticsearch:import:model CLASS='Article' PARENT='author_id'
```

This results in bulk data as follows:

``` json
{"index":{"_id":15,"_parent":1}}
{"id":15,"author_id":1, ... }
```
