### PR TITLE
Allow custom transformations to be defined for bulk imports.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -88,14 +88,15 @@ module Elasticsearch
             scope = named_scope ? self.__send__(named_scope) : self
 
             scope.find_in_batches(options) do |batch|
-              batch_for_bulk = batch.map { |a| { index: { _id: a.id, data: a.__elasticsearch__.as_indexed_json } } }
-              yield batch_for_bulk
+              yield batch
             end
           end
+
+          def __transform
+            lambda {|model|  { index: { _id: model.id, data: model.__elasticsearch__.as_indexed_json } }}
+          end
         end
-
       end
-
     end
   end
 end

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/default.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/default.rb
@@ -36,6 +36,12 @@ module Elasticsearch
           def __find_in_batches(options={}, &block)
             raise NotImplemented, "Method not implemented for default adapter"
           end
+
+          # @abstract Implement this method in your adapter
+          #
+          def __transform
+            raise NotImplemented, "Method not implemented for default adapter"
+          end
         end
 
       end

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
@@ -70,16 +70,18 @@ module Elasticsearch
               items << item
 
               if items.length % options[:batch_size] == 0
-                batch_for_bulk = items.map { |a| { index: { _id: a.id.to_s, data: a.as_indexed_json } } }
-                yield batch_for_bulk
+                yield items
                 items = []
               end
             end
 
             unless items.empty?
-              batch_for_bulk = items.map { |a| { index: { _id: a.id.to_s, data: a.as_indexed_json } } }
-              yield batch_for_bulk
+              yield items
             end
+          end
+
+          def __transform
+            lambda {|a|  { index: { _id: a.id.to_s, data: a.as_indexed_json } }}
           end
         end
 

--- a/elasticsearch-model/test/unit/adapter_active_record_test.rb
+++ b/elasticsearch-model/test/unit/adapter_active_record_test.rb
@@ -104,6 +104,20 @@ class Elasticsearch::Model::AdapterActiveRecordTest < Test::Unit::TestCase
         DummyClassForActiveRecord.__find_in_batches(scope: :published) do; end
       end
 
+      context "when transforming models" do
+        setup do
+          @transform = DummyClassForActiveRecord.__transform
+        end
+
+        should "provide an object that responds to #call" do
+          assert_respond_to @transform, :call
+        end
+
+        should "provide basic transformation" do
+          model = mock("model", id: 1, __elasticsearch__: stub(as_indexed_json: {}))
+          assert_equal @transform.call(model), { index: { _id: 1, data: {} } }
+        end
+      end
     end
   end
 end

--- a/elasticsearch-model/test/unit/adapter_default_test.rb
+++ b/elasticsearch-model/test/unit/adapter_default_test.rb
@@ -19,11 +19,21 @@ class Elasticsearch::Model::AdapterDefaultTest < Test::Unit::TestCase
       assert_instance_of Module, Elasticsearch::Model::Adapter::Default::Callbacks
     end
 
-    should "have the default Importing implementation" do
-      DummyClassForDefaultAdapter.__send__ :include, Elasticsearch::Model::Adapter::Default::Importing
+    context "concerning abstract methods" do
+      setup do
+        DummyClassForDefaultAdapter.__send__ :include, Elasticsearch::Model::Adapter::Default::Importing
+      end
 
-      assert_raise Elasticsearch::Model::NotImplemented do
-        DummyClassForDefaultAdapter.new.__find_in_batches
+      should "have the default Importing implementation" do
+        assert_raise Elasticsearch::Model::NotImplemented do
+          DummyClassForDefaultAdapter.new.__find_in_batches
+        end
+      end
+
+      should "have the default transform implementation" do
+        assert_raise Elasticsearch::Model::NotImplemented do
+          DummyClassForDefaultAdapter.new.__transform
+        end
       end
     end
 

--- a/elasticsearch-model/test/unit/adapter_mongoid_test.rb
+++ b/elasticsearch-model/test/unit/adapter_mongoid_test.rb
@@ -81,6 +81,21 @@ class Elasticsearch::Model::AdapterMongoidTest < Test::Unit::TestCase
         DummyClassForMongoid.__send__ :extend, Elasticsearch::Model::Adapter::Mongoid::Importing
         DummyClassForMongoid.__find_in_batches do; end
       end
+
+      context "when transforming models" do
+        setup do
+          @transform = DummyClassForMongoid.__transform
+        end
+
+        should "provide an object that responds to #call" do
+          assert_respond_to @transform, :call
+        end
+
+        should "provide basic transformation" do
+          model = mock("model", id: 1, as_indexed_json: {})
+          assert_equal @transform.call(model), { index: { _id: "1", data: {} } }
+        end
+      end
     end
 
   end


### PR DESCRIPTION
This allows for the customization of bulk imports. This was driven out of need to include the parent in the index payload, though could extend to any bulk api options.

``` ruby
transform = lambda do |article|
  {index: {_id: article.id, _parent: article.author_id, data: article.__elasticsearch__.as_indexed_json}}
end

Article.import transform: transform
```

This functionality doesn't extend to the rake import task. Will address in a separate PR.
