### PR TITLE
Make it compatible for rails 3.2.x

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,7 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.include? k }
+              changed_attributes.select { |k,v| self.as_indexed_json.keys.map{|k| k.to_s}.include? k }
             else
               changed_attributes
             end


### PR DESCRIPTION
In rails 3.2.x included method are serialized as symbols instead of strings (fixed in newer versions of rails)
