### PR TITLE
Compatibility for rails 3.2

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,8 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.map{|k| k.to_s}.include? k.to_s }
+              indexed_symbols = self.as_indexed_json.keys.map(&:to_sym)
+              changed_attributes.select { |k,v| indexed_symbols.include? k.to_sym }
             else
               changed_attributes
             end

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,7 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.include? k }
+              changed_attributes.select { |k,v| self.as_indexed_json.keys.map{|k| k.to_s}.include? k }
             else
               changed_attributes
             end

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,7 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.map{|k| k.to_s}.include? k }
+              changed_attributes.select { |k,v| self.as_indexed_json.keys.map{|k| k.to_s}.include? k.to_s }
             else
               changed_attributes
             end

--- a/elasticsearch-model/test/integration/active_record_custom_serialization_test.rb
+++ b/elasticsearch-model/test/integration/active_record_custom_serialization_test.rb
@@ -56,6 +56,68 @@ module Elasticsearch
         end
       end
 
+
+      class ::ArticleWithCustomSerializationMethod < ActiveRecord::Base
+        include Elasticsearch::Model
+        include Elasticsearch::Model::Callbacks
+
+        mapping do
+          indexes :tag_list
+        end
+
+        def tag_list=(val)
+          attribute_will_change!('tag_list') unless val == @tag_list
+          @tag_list=val
+        end
+
+        def tag_list
+          @tag_list || 'foo bar'
+        end
+
+        def as_indexed_json(options={})
+          as_json(root: false, methods: [:tag_list])
+        end
+      end
+
+      context "ActiveRecord model with custom JSON serialization including method" do
+        setup do
+          ActiveRecord::Schema.define(:version => 1) do
+            create_table ArticleWithCustomSerializationMethod.table_name do |t|
+              t.string   :title
+            end
+          end
+
+          ArticleWithCustomSerializationMethod.delete_all
+          ArticleWithCustomSerializationMethod.__elasticsearch__.create_index! force: true
+        end
+
+        should "index the tag_list method when creating" do
+          ArticleWithCustomSerializationMethod.create! title: 'Test'
+
+          a = ArticleWithCustomSerializationMethod.__elasticsearch__.client.get \
+                index: 'article_with_custom_serialization_methods',
+                type:  'article_with_custom_serialization_method',
+                id:    '1'
+
+          assert_equal( { 'id'=> 1, 'title'=> 'Test', 'tag_list' => 'foo bar' }, a['_source'] )
+        end
+
+        should "index the updated tag_list attribute when updating" do
+          ArticleWithCustomSerializationMethod.create! title: 'Test'
+
+          article = ArticleWithCustomSerializationMethod.first
+          article.tag_list='UPDATED'
+          article.save!
+
+          a = ArticleWithCustomSerializationMethod.__elasticsearch__.client.get \
+                index: 'article_with_custom_serialization_methods',
+                type:  'article_with_custom_serialization_method',
+                id:    '1'
+
+          assert_equal( { 'id'=> 1, 'title'=> 'Test', 'tag_list' => 'UPDATED' }, a['_source'] )
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Rails to serialize model names to symbols instead of strings. Fixed in more recent versions of Rails.