### PR TITLE
Elasticsearch::Model::Response::Result not delegating type to source

### DIFF
--- a/elasticsearch-model/test/unit/response_result_test.rb
+++ b/elasticsearch-model/test/unit/response_result_test.rb
@@ -16,7 +16,7 @@ class Elasticsearch::Model::ResultTest < Test::Unit::TestCase
     end
 
     should "delegate method calls to `_source` when available" do
-      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _source: { bar: 'baz' }
+      result = Elasticsearch::Model::Response::Result.new foo: 'bar', _source: { bar: 'baz', type: 'quux' }
 
       assert_respond_to result, :foo
       assert_respond_to result, :_source
@@ -25,6 +25,7 @@ class Elasticsearch::Model::ResultTest < Test::Unit::TestCase
       assert_equal 'bar', result.foo
       assert_equal 'baz', result._source.bar
       assert_equal 'baz', result.bar
+      assert_equal 'quux', result.type
     end
 
     should "delegate existence method calls to `_source`" do


### PR DESCRIPTION
I have an `Elasticsearch::Model::Response::Result` where the source has a type field, the result in this case returns `nil` instead of the value. This test checks what I believe is incorrect behavior. If you could point me to where I might be able to make the fix for this I can include it.
