### PR TITLE
[MODEL] Searching multiple models

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -169,6 +169,19 @@ response.results.first._source.title
 # => "Quick brown fox"
 ```
 
+We can also search across multiple models:
+
+```ruby
+response = Elasticsearch::Model.search('fox', [Article, Author])
+
+response.results.first._index
+# => "articles"
+
+response.results.last._index
+# => "authors"
+
+```
+
 #### Search results
 
 The returned `response` object is a rich wrapper around the JSON returned from Elasticsearch,
@@ -248,6 +261,8 @@ response.records.each_with_hit { |record, hit| puts "* #{record.title}: #{hit._s
 # * Quick brown fox: 0.02250402
 # * Fast black dogs: 0.02250402
 ```
+
+**NOTE**: A multiple-model search `response` does not currently support the `records` method.
 
 #### Pagination
 

--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -19,6 +19,7 @@ require 'elasticsearch/model/naming'
 require 'elasticsearch/model/serializing'
 require 'elasticsearch/model/searching'
 require 'elasticsearch/model/callbacks'
+require 'elasticsearch/model/multiple_models'
 
 require 'elasticsearch/model/proxy'
 
@@ -147,6 +148,29 @@ module Elasticsearch
       #
       def client=(client)
         @client = client
+      end
+
+      # Search across models which include Elasticsearch::Model
+      #
+      # @param query_or_payload [String,Hash,Object] The search request definition
+      #                                              (string, JSON, Hash, or object responding to `to_hash`)
+      # @param models [Array] The list of Model objects to search
+      # @param options [Hash] Optional parameters to be passed to the Elasticsearch client
+      #
+      # @return [Elasticsearch::Model::Response::Response]
+      #
+      # @example Search across specified models
+      #
+      #     Elasticsearch::Model.search('foo', [Author, Article])
+      #
+      # @example Search across all models
+      #
+      #     Elasticsearch::Model.search('foo')
+      #
+      def search(query_or_payload, models=[], options={})
+        models = MultipleModels.new(models)
+        search = Searching::SearchRequest.new(models, query_or_payload, options)
+        Response::Response.new(models, search)
       end
 
     end

--- a/elasticsearch-model/lib/elasticsearch/model/multiple_models.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multiple_models.rb
@@ -1,0 +1,42 @@
+module Elasticsearch
+  module Model
+
+    class MultipleModels < Array
+      def initialize(models=[])
+        models = models.empty? ? __searchable_models : models
+        super(models)
+      end
+
+      def client
+        Elasticsearch::Model.client
+      end
+
+      def ancestors
+        []
+      end
+
+      def default_per_page
+        10
+      end
+
+      def inspect
+        "MultipleModels: #{super}"
+      end
+
+      def index_name
+        map { |m| m.index_name }
+      end
+
+      def document_type
+        map { |m| m.document_type }
+      end
+
+      def __searchable_models
+        Object.constants
+          .select { |c| Kernel.const_get(c).respond_to?(:__elasticsearch__) }
+          .map    { |c| c.is_a?(Class) ? c : Kernel.const_get(c) }
+      end
+    end
+
+  end
+end

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -43,6 +43,7 @@ module Elasticsearch
         # @return [Records]
         #
         def records
+          raise NotImplementedError, "Method not implemented for multiple model search" if klass.instance_of? MultipleModels
           @records ||= Records.new(klass, self)
         end
 

--- a/elasticsearch-model/test/integration/model_basic_test.rb
+++ b/elasticsearch-model/test/integration/model_basic_test.rb
@@ -51,6 +51,13 @@ module Elasticsearch
           assert_equal response.results.total, 2
         end
 
+        should "raise an error when calling records on the response" do
+          response = Elasticsearch::Model.search('test white', [ArticleModel, AuthorModel])
+          assert_raises(NotImplementedError) do
+            response.records
+          end
+        end
+
         should "search across all models" do
           MultipleModels.any_instance.expects(:__searchable_models).returns([ArticleModel, AuthorModel])
 

--- a/elasticsearch-model/test/integration/model_basic_test.rb
+++ b/elasticsearch-model/test/integration/model_basic_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'elasticsearch/model'
+
+module Elasticsearch
+  module Model
+    class ModelBasicIntgrationTest < Elasticsearch::Test::IntegrationTestCase
+
+      class ArticleModel
+        include ActiveModel::Model
+        include Elasticsearch::Model
+
+        attr_accessor :id, :title
+
+        def self.create!(attrs={})
+          new(attrs).__elasticsearch__.index_document
+        end
+
+        def as_indexed_json(options={})
+          {id: id, title: title}
+        end
+      end
+
+      class AuthorModel
+        include ActiveModel::Model
+        include Elasticsearch::Model
+
+        attr_accessor :id, :name, :title
+
+        def self.create!(attrs={})
+          new(attrs).__elasticsearch__.index_document
+        end
+
+        def as_indexed_json(options={})
+          {id: id, title: title, name: name}
+        end
+      end
+
+      context "Model search" do
+        setup do
+          ArticleModel.create! id: 1, title: 'Test'
+          AuthorModel.create!  id: 1, title: 'Mr', name: "Jack White"
+        end
+
+        should "search specific model" do
+          response = Elasticsearch::Model.search('test white', [ArticleModel])
+          assert_equal response.results.total, 1
+        end
+
+        should "search across multiple models" do
+          response = Elasticsearch::Model.search('test white', [ArticleModel, AuthorModel])
+          assert_equal response.results.total, 2
+        end
+
+        should "search across all models" do
+          MultipleModels.any_instance.expects(:__searchable_models).returns([ArticleModel, AuthorModel])
+
+          response = Elasticsearch::Model.search('test white')
+          assert_equal response.results.total, 2
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-model/test/unit/module_test.rb
+++ b/elasticsearch-model/test/unit/module_test.rb
@@ -20,6 +20,19 @@ class Elasticsearch::Model::ModuleTest < Test::Unit::TestCase
       end
     end
 
+    context "search" do
+      should "initialize the search object" do
+        Elasticsearch::Model::Searching::SearchRequest
+          .expects(:new).with do |klass, query, options|
+            assert_equal Elasticsearch::Model::MultipleModels, klass.class
+            assert_equal 'foo', query
+          end
+          .returns( stub('search') )
+
+          Elasticsearch::Model.search('foo', [mock('SearchableModel')])
+      end
+    end
+
     context "when included in module/class, " do
       class ::DummyIncludingModel; end
       class ::DummyIncludingModelWithSearchMethodDefined

--- a/elasticsearch-model/test/unit/multiple_models_test.rb
+++ b/elasticsearch-model/test/unit/multiple_models_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class Elasticsearch::Model::MultipleModelsTest < Test::Unit::TestCase
+  context "initializing" do
+    class ::DummySearchableModel
+      include Elasticsearch::Model
+    end
+
+    context "with multiple models" do
+      setup do
+        @model_one = mock('ModelOne')
+        @model_one.stubs(index_name: 'model_one', document_type: 'model_one_type')
+
+        @model_two = mock('ModelTwo')
+        @model_two.stubs(index_name: 'model_two', document_type: 'model_two_type')
+
+        @multiple_models = Elasticsearch::Model::MultipleModels.new([@model_one, @model_two])
+      end
+
+      should "enumerate only specified models" do
+        assert_equal    @multiple_models.size, 2
+        assert_includes @multiple_models, @model_one
+        assert_includes @multiple_models, @model_two
+      end
+
+      should "define indexes to search" do
+        assert_equal @multiple_models.index_name, ['model_one', 'model_two']
+      end
+
+      should "define document type to search" do
+        assert_equal @multiple_models.document_type, ['model_one_type', 'model_two_type']
+      end
+
+      should "have specific default per page" do
+        assert_equal @multiple_models.default_per_page, 10
+      end
+
+      should "have no ancestors" do
+        assert_equal @multiple_models.ancestors, []
+      end
+
+      should "have access to the model client" do
+        begin
+          Elasticsearch::Model.client = "Foobar"
+          assert_equal @multiple_models.client, Elasticsearch::Model.client
+        ensure
+          Elasticsearch::Model.client = nil
+        end
+      end
+
+      should "respond to inspect" do
+        assert_equal @multiple_models.inspect, "MultipleModels: #{[@model_one, @model_two].inspect}"
+      end
+    end
+
+    should "enumerate all available elasticsearch models" do
+      Object.expects(:constants).returns([:DummySearchableModel])
+
+      multiple_models = Elasticsearch::Model::MultipleModels.new
+      assert_includes multiple_models, DummySearchableModel
+      assert_equal    multiple_models.size, 1
+    end
+  end
+end

--- a/elasticsearch-model/test/unit/response_test.rb
+++ b/elasticsearch-model/test/unit/response_test.rb
@@ -48,6 +48,11 @@ class Elasticsearch::Model::ResponseTest < Test::Unit::TestCase
       assert response.empty?
     end
 
+    should "raise an error calling records on MultipleModels" do
+      response = Elasticsearch::Model::Response::Response.new Elasticsearch::Model::MultipleModels.new, @search
+      assert_raises(NotImplementedError) { response.records }
+    end
+
     should "be initialized lazily" do
       @search.expects(:execute!).never
 


### PR DESCRIPTION
This takes the example code that @karmi presented in https://github.com/elasticsearch/elasticsearch-rails/issues/10 and exposes it via `Elasticseach::Model#search` 

Basic usage is:
```ruby
response = Elasticsearch::Model.search('jaguar', [Animal, Automobile])
```