### PR TITLE
Implement Elasticsearch::Model::Response::Pagination::WillPaginate#offset

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -102,9 +102,13 @@ module Elasticsearch
 
             # Include the paging methods in results and records
             #
-            methods = [:current_page, :per_page, :total_entries, :total_pages, :previous_page, :next_page, :out_of_bounds?]
+            methods = [:current_page, :offset, :per_page, :total_entries, :total_pages, :previous_page, :next_page, :out_of_bounds?]
             Elasticsearch::Model::Response::Results.__send__ :delegate, *methods, to: :response
             Elasticsearch::Model::Response::Records.__send__ :delegate, *methods, to: :response
+          end
+
+          def offset
+            (current_page - 1) * per_page
           end
 
           # Main pagination method

--- a/elasticsearch-model/test/unit/response_pagination_will_paginate_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_will_paginate_test.rb
@@ -30,6 +30,7 @@ class Elasticsearch::Model::ResponsePaginationWillPaginateTest < Test::Unit::Tes
       @expected_methods = [
         # methods needed by WillPaginate::CollectionMethods
         :current_page,
+        :offset,
         :per_page,
         :total_entries,
 
@@ -63,6 +64,13 @@ class Elasticsearch::Model::ResponsePaginationWillPaginateTest < Test::Unit::Tes
           @response.klass.stubs(:find).returns([])
           assert_respond_to @response.records, method
         end
+      end
+    end
+
+    context "#offset method" do
+      should "calculate offset using current_page and per_page" do
+        @response.per_page(3).page(3)
+        assert_equal 6, @response.offset
       end
     end
 


### PR DESCRIPTION
Fixes #131.

This was a silly mistake on my part, since [`will_paginate` documents that this method is required](https://github.com/mislav/will_paginate/blob/ca7d45f955066f0a01d500769a8efbb6acc4032c/lib/will_paginate/collection.rb#L7).

I've also submitted https://github.com/mislav/will_paginate/pull/381

I've tested `page_entries_info` in a Rails 4.1.1 app. @johvet Can you please verify this fix in your app?
