### PR TITLE
Support 1.0-style multi_fields in the mapping DSL

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -36,6 +36,9 @@ module Elasticsearch
       class Mappings
         attr_accessor :options
 
+        # @private
+        TYPES_WITH_EMBEDDED_PROPERTIES = %w(object nested)
+
         def initialize(type, options={})
           raise ArgumentError, "`type` is missing" if type.nil?
 
@@ -49,7 +52,7 @@ module Elasticsearch
 
           if block_given?
             @mapping[name][:type] ||= 'object'
-            properties = @mapping[name][:type] == 'multi_field' ? :fields : :properties
+            properties = TYPES_WITH_EMBEDDED_PROPERTIES.include?(@mapping[name][:type]) ? :properties : :fields
 
             @mapping[name][properties] ||= {}
 

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -74,27 +74,36 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         assert_equal 'string', mappings.to_hash[:mytype][:properties][:bar][:type]
       end
 
-      should "define embedded properties" do
-        mappings = Elasticsearch::Model::Indexing::Mappings.new :mytype
+      %w(string long double boolean multi_field).each do |outer_type|
+        should "define embedded fields for #{outer_type}" do
+          mappings = Elasticsearch::Model::Indexing::Mappings.new :mytype
 
-        mappings.indexes :foo do
-          indexes :bar
+          mappings.indexes :foo, type: outer_type do
+            indexes :raw, analyzer: 'keyword'
+          end
+
+          foo_mapping = mappings.to_hash[:mytype][:properties][:foo]
+
+          assert_equal outer_type, foo_mapping[:type]
+          assert_nil foo_mapping[:properties]
+          assert_equal 'string', foo_mapping[:fields][:raw][:type]
         end
-
-        mappings.indexes :multi, type: 'multi_field' do
-          indexes :multi, analyzer: 'snowball'
-          indexes :raw,   analyzer: 'keyword'
-        end
-
-        assert_equal 'object', mappings.to_hash[:mytype][:properties][:foo][:type]
-        assert_equal 'string', mappings.to_hash[:mytype][:properties][:foo][:properties][:bar][:type]
-
-        assert_equal 'multi_field', mappings.to_hash[:mytype][:properties][:multi][:type]
-        assert_equal 'snowball', mappings.to_hash[:mytype][:properties][:multi][:fields][:multi][:analyzer]
-        assert_equal 'keyword',  mappings.to_hash[:mytype][:properties][:multi][:fields][:raw][:analyzer]
       end
 
-      should "define multi_field properties" do
+      %w(object nested).each do |outer_type|
+        should "define embedded properties for #{outer_type}" do
+          mappings = Elasticsearch::Model::Indexing::Mappings.new :mytype
+
+          mappings.indexes :foo, type: outer_type do
+            indexes :bar
+          end
+
+          foo_mapping = mappings.to_hash[:mytype][:properties][:foo]
+
+          assert_equal outer_type, foo_mapping[:type]
+          assert_nil foo_mapping[:fields]
+          assert_equal 'string', foo_mapping[:properties][:bar][:type]
+        end
       end
     end
 


### PR DESCRIPTION
This branch updates the `mapping` DSL to have nested `indexes` calls produce embedded fields (instead of properties) for the core types where this is appropriate.

This mapping syntax is allowed starting with [elasticsearch 1.0][es10mf] as a replacement for `multi_field`.

[es10mf]: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_multi_fields.html

`type: "multi_field"` will still work as before; this change should not break backwards compatibility.

A workaround before this patch (or its equivalent) is merged is to define the nested fields using a hash. E.g.:

```
indexes :foo, type: 'string', fields: { raw: { type: "string", analyzer: "keywords" } }
```

With this patch, the same mapping can be written as:

```
indexes :foo, type: 'string' do
  indexes :raw, analyzer: 'keywords'
end