### PR TITLE
Fix changed attributes matching

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,7 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.include? k }
+              changed_attributes.select { |k,v| self.as_indexed_json.keys.map(&:to_s).include? k.to_s }
             else
               changed_attributes
             end


### PR DESCRIPTION
If I define `as_indexed_json` function to return symbol-keyed hash then the changes will not be detected because if I changed name:

```
def as_indexed_json
  {name: name} 
end

as_indexed_json.keys.include? 'name' #=> false
```

Thus I recommend to compare string variants.
