### PR TITLE
[STORE] Added id= method for setting model instance id

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/base.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/base.rb
@@ -25,6 +25,12 @@ module Elasticsearch
             @_id
           end; alias :_id :id
 
+          # Set the document `_id`
+          #
+          def id=(value)
+            @_id = value
+          end; alias :_id= :id=
+
           # Return the document `_index`
           #
           def _index

--- a/elasticsearch-persistence/test/unit/model_base_test.rb
+++ b/elasticsearch-persistence/test/unit/model_base_test.rb
@@ -27,6 +27,13 @@ class Elasticsearch::Persistence::ModelBaseTest < Test::Unit::TestCase
       assert_equal 2, m.id
     end
 
+    should "set the ID using setter method" do
+      m = DummyBaseModel.new id: 1
+      m.id = 2
+
+      assert_equal 2, m.id
+    end
+
     should "have ID in attributes" do
       m = DummyBaseModel.new id: 1, name: 'Test'
       assert_equal 1, m.attributes[:id]


### PR DESCRIPTION
Hello,

we need sometimes to change instance `id` after its initialization.

For example, it seems [FactoryGirl](https://github.com/thoughtbot/factory_girl) is setting attributes using instance setter methods...

Thank you
