### PR TITLE
Partial update behavior

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -336,7 +336,11 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              changed_attributes.select { |k,v| self.as_indexed_json.keys.include? k }
+              json = self.as_indexed_json
+              changed_attributes.inject({}) do |memo,(key,value)|
+                memo[key] = json[key] if json.keys.include? key
+                memo
+              end
             else
               changed_attributes
             end

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -295,6 +295,24 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
 
         instance.update_document
       end
+
+      should "get attributes from as_indexed_json during partial update" do
+        client   = mock('client')
+        instance = ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJson.new
+
+        instance.instance_variable_set(:@__changed_attributes, {foo: {ru:'B'} })
+
+        client.expects(:update).with do |payload|
+          assert_equal({foo: 'B'}, payload[:body][:doc])
+        end
+
+        instance.expects(:client).returns(client)
+        instance.expects(:index_name).returns('foo')
+        instance.expects(:document_type).returns('bar')
+        instance.expects(:id).returns('1')
+
+        instance.update_document
+      end
     end
 
     context "Re-creating the index" do


### PR DESCRIPTION
I got issue with localized fields(mongoid), after migrating from `tire` gem.

``` ruby
class Book
  include Mongoid::Document
  include Elasticsearch::Model
  include Elasticsearch::Model::Callbacks

  field :title, localized: true

  mapping do
    indexes :title, analyzer: "russian_morphology"
  end

  def as_indexed_json(opts={})
    {
      title: title
    }
  end
end

book = Book.create(title: "My book")
book.title = "My book 2"

book.changed_attributes # => {title: {ru: "My book 2"}}
book.as_indexed_json # => {title: "My book 2}

book.save
# Elasticsearch::Transport::Transport::Errors::BadRequest:
#       [400] {"error":"MapperParsingException[failed to parse [title]]; nested: ElasticsearchIllegalArgumentException[unknown property [ru]]; ","status":400}

```

Can we change this behavior a bit?
