### PR TITLE
update document should update with hash from as_indexed_json.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -393,8 +393,8 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              indexed_json = self.as_indexed_json
-              (self.attributes.keys - changed_attributes.keys).map(&:to_s).each{ |k| indexed_json.delete(k) }
+              indexed_json = self.as_indexed_json.with_indifferent_access
+              (self.attributes.keys.map(&:to_s) - changed_attributes.keys.map(&:to_s)).each{ |k| indexed_json.delete(k) }
               indexed_json
             else
               changed_attributes

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -393,8 +393,8 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              indexed_json = self.as_indexed_json.with_indifferent_access
-              (self.attributes.keys.map(&:to_s) - changed_attributes.keys.map(&:to_s)).each{ |k| indexed_json.delete(k) }
+              indexed_json = self.as_indexed_json
+              (self.attributes.keys.map(&:to_s) - changed_attributes.keys.map(&:to_s)).each{ |k| indexed_json.delete_if{ |a,b| a.to_s == k } }
               indexed_json
             else
               changed_attributes

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -393,7 +393,9 @@ module Elasticsearch
         def update_document(options={})
           if changed_attributes = self.instance_variable_get(:@__changed_attributes)
             attributes = if respond_to?(:as_indexed_json)
-              self.as_indexed_json.select { |k,v| changed_attributes.keys.map(&:to_s).include? k.to_s }
+              indexed_json = self.as_indexed_json
+              (self.attributes.keys - changed_attributes.keys).map(&:to_s).each{ |k| indexed_json.delete(k) }
+              indexed_json
             else
               changed_attributes
             end

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -406,6 +406,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
 
         client.expects(:update).with do |payload|
           assert_equal({'foo' => 'BAR'}, payload[:body][:doc])
+          true
         end
 
         instance.expects(:client).returns(client)

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -195,6 +195,27 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         end
 
         def as_indexed_json(options={})
+          { :foo => 'B' }
+        end
+      end
+
+      class ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJsonMultiValue
+        extend  Elasticsearch::Model::Indexing::ClassMethods
+        include Elasticsearch::Model::Indexing::InstanceMethods
+
+        def self.before_save(&block)
+          (@callbacks ||= {})[block.hash] = block
+        end
+
+        def attributes; { :_id => 1, :foo => 'B', :bar => 'D', :baz => 'F' }; end
+
+        def changed_attributes; [:foo, :bar]; end
+
+        def changes
+          {:foo => ['A', 'B'], :bar => ['C', 'D']}
+        end
+
+        def as_indexed_json(options={})
           { :foo => 'B', :bar => 'D' }
         end
       end

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -186,6 +186,8 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
           (@callbacks ||= {})[block.hash] = block
         end
 
+        def attributes; { :_id => 1, :foo => 'B', :bar => 'D', :baz => 'F' }; end
+
         def changed_attributes; [:foo, :bar]; end
 
         def changes
@@ -193,7 +195,32 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         end
 
         def as_indexed_json(options={})
-          { :foo => 'B' }
+          { :foo => 'B', :bar => 'D' }
+        end
+      end
+
+      class ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJsonWithDerivedAttribute
+        extend  Elasticsearch::Model::Indexing::ClassMethods
+        include Elasticsearch::Model::Indexing::InstanceMethods
+
+        def self.before_save(&block)
+          (@callbacks ||= {})[block.hash] = block
+        end
+
+        def attributes; { :_id => 1, :foo => 'B', :bar => 'D', :baz => 'F' }; end
+
+        def changed_attributes; [:foo, :bar]; end
+
+        def changes
+          {:foo => ['A', 'B'], :bar => ['C', 'D']}
+        end
+
+        def as_indexed_json(options={})
+          { :foo => 'B', :bar => 'D', :qux => derived_value }
+        end
+
+        def derived_value
+          'E'
         end
       end
 
@@ -356,6 +383,26 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
 
         client.expects(:update).with do |payload|
           assert_equal({'foo' => 'BAR'}, payload[:body][:doc])
+          true
+        end
+
+        instance.expects(:client).returns(client)
+        instance.expects(:index_name).returns('foo')
+        instance.expects(:document_type).returns('bar')
+        instance.expects(:id).returns('1')
+
+        instance.update_document
+      end
+
+      should "include derived attributes from custom as_indexed_json during partial update" do
+        client   = mock('client')
+        instance = ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJsonWithDerivedAttribute.new
+
+        # Set the fake `changes` hash
+        instance.instance_variable_set(:@__changed_attributes, {foo: 'B'})
+
+        client.expects(:update).with do |payload|
+          assert_equal({foo: 'B', qux: 'E'}, payload[:body][:doc])
           true
         end
 


### PR DESCRIPTION
update document should update with hash from as_indexed_json which could also contain derived attributes.
resolves #178
this also should resolve issues #88 #166 and #195 
