### PR TITLE
Call import on proxy object

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -59,7 +59,8 @@ namespace :elasticsearch do
         rescue NoMethodError; end
       end
 
-      total_errors = klass.import force:      ENV.fetch('FORCE', false),
+      total_errors = klass.__elasticsearch__.import \
+                                  force:      ENV.fetch('FORCE', false),
                                   batch_size: ENV.fetch('BATCH', 1000).to_i,
                                   index:      ENV.fetch('INDEX', nil),
                                   type:       ENV.fetch('TYPE',  nil),


### PR DESCRIPTION
elasticsearch-model is very careful to not override any method names on
model classes if they already exist. When this happens you have to use
the __elasticsearch__ proxy object directly. That's great but the
elasticsearch-rails import rake task does not respect that.

In our case there is a conflict with the activerecord-import gem which
defines an import method on ActiveRecord::Base. The way the rake task
was written it was ending up calling activerecord-import's version of
import instead of elasticsearch-model's version.

This change simply forces the rake task to use the proxy object.