### PR TITLE
remove duplicate article.rb-related content in expert template - caused ...

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/03-expert.rb
+++ b/elasticsearch-rails/lib/rails/templates/03-expert.rb
@@ -111,17 +111,6 @@ gsub_file "app/models/authorship.rb", %r{belongs_to :article$}, <<-CODE
 belongs_to :article, touch: true
 CODE
 
-insert_into_file "app/models/article.rb", after: "ActiveRecord::Base" do
-  <<-CODE
-
-  has_and_belongs_to_many :categories, after_add:    [ lambda { |a,c| Indexer.perform_async(:update,  a.class.to_s, a.id) } ],
-                                       after_remove: [ lambda { |a,c| Indexer.perform_async(:update,  a.class.to_s, a.id) } ]
-  has_many                :authorships
-  has_many                :authors, through: :authorships
-  has_many                :comments
-  CODE
-end
-
 gsub_file "app/models/comment.rb", %r{belongs_to :article$}, <<-CODE
 belongs_to :article, touch: true
 CODE


### PR DESCRIPTION
...template install to fail

There was some repeated text in the expert template which was causing the install to fail.

It was attempting to add text to the article.rb file before that file existed.  I excised the offending code.
