### PR TITLE
02-pretty elasticsearch-rails kaminari:views generation fix

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/02-pretty.rb
+++ b/elasticsearch-rails/lib/rails/templates/02-pretty.rb
@@ -218,7 +218,7 @@ insert_into_file 'app/views/articles/index.html.erb', after: '</table>' do
   CODE
 end
 
-generate "kaminari:views", "bootstrap", "--force"
+generate "kaminari:views", "bootstrap2", "--force"
 
 gsub_file 'app/views/kaminari/_paginator.html.erb', %r{<ul>}, '<ul class="pagination">'
 


### PR DESCRIPTION
If you try to install second test app, you will see following error:
`no such theme: bootstrap`
`avaliable themes: bootstrap2, bootstrap3, foundation, github, google`
and installation will be stopped. So I added an easy fix.
