### PR TITLE
[MODEL] Limit the record to import by a query

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -146,7 +146,7 @@ Article.import
 # => 0
 ```
 
-It's possible to import only records from a specific `scope`, transform the batch with the `transform`
+It's possible to import only records from a specific `scope` or `query`, transform the batch with the `transform`
 and `preprocess` options, or re-create the index by deleting it and creating it with correct mapping with the `force` option -- look for examples in the method documentation.
 
 No errors were reported during importing, so... let's search the index!

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -84,10 +84,13 @@ module Elasticsearch
           # @see http://api.rubyonrails.org/classes/ActiveRecord/Batches.html ActiveRecord::Batches.find_in_batches
           #
           def __find_in_batches(options={}, &block)
+            query = options.delete(:query)
             named_scope = options.delete(:scope)
             preprocess = options.delete(:preprocess)
 
-            scope = named_scope ? self.__send__(named_scope) : self
+            scope = self
+            scope = scope.__send__(named_scope) if named_scope
+            scope = scope.instance_exec(&query) if query
 
             scope.find_in_batches(options) do |batch|
               yield (preprocess ? self.__send__(preprocess, batch) : batch)

--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -68,6 +68,10 @@ module Elasticsearch
         #
         #    Article.import scope: 'published'
         #
+        # @example Pass an ActiveRecord query to limit the imported records
+        #
+        #    Article.import query: -> { where(author_id: author_id) }
+        #
         # @example Transform records during the import with a lambda
         #
         #    transform = lambda do |a|

--- a/elasticsearch-model/test/integration/active_record_import_test.rb
+++ b/elasticsearch-model/test/integration/active_record_import_test.rb
@@ -62,6 +62,15 @@ module Elasticsearch
           assert_equal 50, ImportArticle.search('*').results.total
         end
 
+        should "import only documents from a specific query" do
+          assert_equal 100, ImportArticle.count
+
+          assert_equal 0, ImportArticle.import(query: -> { where('views >= 30') })
+
+          ImportArticle.__elasticsearch__.refresh_index!
+          assert_equal 70, ImportArticle.search('*').results.total
+        end
+
         should "report and not store/index invalid documents" do
           ImportArticle.create! title: "Test INVALID", numeric: "INVALID"
 

--- a/elasticsearch-model/test/unit/adapter_active_record_test.rb
+++ b/elasticsearch-model/test/unit/adapter_active_record_test.rb
@@ -104,6 +104,13 @@ class Elasticsearch::Model::AdapterActiveRecordTest < Test::Unit::TestCase
         DummyClassForActiveRecord.__find_in_batches(scope: :published) do; end
       end
 
+      should "limit the relation to a specific query" do
+        DummyClassForActiveRecord.expects(:find_in_batches).returns([])
+        DummyClassForActiveRecord.expects(:where).returns(DummyClassForActiveRecord)
+
+        DummyClassForActiveRecord.__find_in_batches(query: -> { where(color: "red") }) do; end
+      end
+
       should "preprocess the batch if option provided" do
         class << DummyClassForActiveRecord
           # Updates/transforms the batch while fetching it from the database


### PR DESCRIPTION
Hello, it can be convenient to limit the query to import by a query, in development mode for example. So, I added this option. What do you think of it?
