### PR TITLE
On #import, raise an error if the index does not exists.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -114,6 +114,9 @@ module Elasticsearch
 
           if options.delete(:force)
             self.create_index! force: true, index: target_index
+          elsif !self.index_exists? index: target_index
+            raise ArgumentError,
+                  "#{target_index} does not exist to be imported into. Use create_index! or the :force option to create it."
           end
 
           __find_in_batches(options) do |batch|

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -224,12 +224,28 @@ module Elasticsearch
 
           delete_index!(options.merge index: target_index) if options[:force]
 
-          unless ( self.client.indices.exists(index: target_index) rescue false )
+          unless index_exists?(index: target_index)
             self.client.indices.create index: target_index,
                                        body: {
                                          settings: self.settings.to_hash,
                                          mappings: self.mappings.to_hash }
           end
+        end
+
+        # Returns true if the index exists
+        #
+        # @example Check whether the model's index exists
+        #
+        #     Article.__elasticsearch__.index_exists?
+        #
+        # @example Check whether a specific index exists
+        #
+        #     Article.__elasticsearch__.index_exists? index: 'my-index'
+        #
+        def index_exists?(options={})
+          target_index = options[:index] || self.index_name
+
+          self.client.indices.exists(index: target_index) rescue false
         end
 
         # Deletes the index with corresponding name

--- a/elasticsearch-model/test/unit/importing_test.rb
+++ b/elasticsearch-model/test/unit/importing_test.rb
@@ -44,6 +44,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       DummyImportingModel.expects(:client).returns(client)
       DummyImportingModel.expects(:index_name).returns('foo')
       DummyImportingModel.expects(:document_type).returns('foo')
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.stubs(:__batch_to_bulk)
       assert_equal 0, DummyImportingModel.import
     end
@@ -61,6 +62,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       DummyImportingModel.stubs(:client).returns(client)
       DummyImportingModel.stubs(:index_name).returns('foo')
       DummyImportingModel.stubs(:document_type).returns('foo')
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.stubs(:__batch_to_bulk)
 
       assert_equal 1, DummyImportingModel.import
@@ -79,6 +81,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       DummyImportingModel.stubs(:client).returns(client)
       DummyImportingModel.stubs(:index_name).returns('foo')
       DummyImportingModel.stubs(:document_type).returns('foo')
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.stubs(:__batch_to_bulk)
 
       assert_equal [{'index' => {'error' => 'FAILED'}}], DummyImportingModel.import(return: 'errors')
@@ -97,6 +100,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       DummyImportingModel.stubs(:client).returns(client)
       DummyImportingModel.stubs(:index_name).returns('foo')
       DummyImportingModel.stubs(:document_type).returns('foo')
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.stubs(:__batch_to_bulk)
 
       DummyImportingModel.import do |response|
@@ -104,22 +108,41 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       end
     end
 
-    should "delete and create the index with the force option" do
-      DummyImportingModel.expects(:__find_in_batches).with do |options|
-        assert_equal 'bar', options[:foo]
-        assert_nil   options[:force]
-        true
+    context "when the index does not exist" do
+      should "raise" do
+        Elasticsearch::Model::Adapter.expects(:from_class)
+                                     .with(DummyImportingModel)
+                                     .returns(DummyImportingAdapter)
+
+        DummyImportingModel.__send__ :include, Elasticsearch::Model::Importing
+
+        DummyImportingModel.expects(:index_name).returns('foo')
+        DummyImportingModel.expects(:document_type).returns('foo')
+        DummyImportingModel.expects(:index_exists?).returns(false)
+        assert_raise ArgumentError do
+          DummyImportingModel.import
+        end
       end
+    end
 
-      DummyImportingModel.expects(:create_index!).with do |options|
-        assert_equal true, options[:force]
-        true
+    context "with the force option" do
+      should "delete and create the index" do
+        DummyImportingModel.expects(:__find_in_batches).with do |options|
+          assert_equal 'bar', options[:foo]
+          assert_nil   options[:force]
+          true
+        end
+
+        DummyImportingModel.expects(:create_index!).with do |options|
+          assert_equal true, options[:force]
+          true
+        end
+
+        DummyImportingModel.expects(:index_name).returns('foo')
+        DummyImportingModel.expects(:document_type).returns('foo')
+
+        DummyImportingModel.import force: true, foo: 'bar'
       end
-
-      DummyImportingModel.expects(:index_name).returns('foo')
-      DummyImportingModel.expects(:document_type).returns('foo')
-
-      DummyImportingModel.import force: true, foo: 'bar'
     end
 
     should "allow passing a different index / type" do
@@ -141,6 +164,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
         .returns({'items' => [ {'index' => {} }]})
 
       DummyImportingModel.stubs(:client).returns(client)
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.stubs(:__batch_to_bulk)
 
       DummyImportingModel.import index: 'my-new-index', type: 'my-other-type'
@@ -151,6 +175,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       transform = lambda {|a|}
 
       DummyImportingModel.stubs(:client).returns(client)
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.expects(:__transform).returns(transform)
       DummyImportingModel.expects(:__batch_to_bulk).with(anything, transform)
 
@@ -162,6 +187,7 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       transform = lambda {|a|}
 
       DummyImportingModel.stubs(:client).returns(client)
+      DummyImportingModel.stubs(:index_exists?).returns(true)
       DummyImportingModel.expects(:__batch_to_bulk).with(anything, transform)
 
       DummyImportingModel.import index: 'foo', type: 'bar', transform: transform


### PR DESCRIPTION
This is to avoid the index being created based on the structure of the bulk import json.

Extract `#index_exists?` to serve.

Inspired by #243.