### PR TITLE
Support inherited index names and doc types

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -149,6 +149,24 @@ module Elasticsearch
         @client = client
       end
 
+      # Check if inheritance is enabled
+      #
+      # @note Inheritance is disabled by default.
+      #
+      def inheritance_enabled
+        @inheritance_enabled ||= false
+      end
+
+      # Enable inheritance of index_name and document_type
+      #
+      # @example Enable inheritance
+      #
+      #     Elasticsearch::Model.inheritance_enabled = true
+      #
+      def inheritance_enabled=(inheritance_enabled)
+        @inheritance_enabled = inheritance_enabled
+      end
+
     end
     extend ClassMethods
 

--- a/elasticsearch-model/test/unit/naming_inheritance_test.rb
+++ b/elasticsearch-model/test/unit/naming_inheritance_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class Elasticsearch::Model::NamingInheritanceTest < Test::Unit::TestCase
+  def setup
+    Elasticsearch::Model.inheritance_enabled = true
+  end
+
+  def teardown
+    Elasticsearch::Model.inheritance_enabled = false
+  end
+
+  context "Naming module with inheritance" do
+    class ::TestBase
+      extend ActiveModel::Naming
+
+      extend  Elasticsearch::Model::Naming::ClassMethods
+      include Elasticsearch::Model::Naming::InstanceMethods
+    end
+
+    class ::Animal < ::TestBase
+      extend ActiveModel::Naming
+
+      extend  Elasticsearch::Model::Naming::ClassMethods
+      include Elasticsearch::Model::Naming::InstanceMethods
+
+      index_name "mammals"
+      document_type "mammal"
+    end
+
+    class ::Dog < ::Animal
+    end
+
+    module ::MyNamespace
+      class Dog < ::Animal
+      end
+    end
+
+    should "return the default index_name" do
+      assert_equal "test_bases", TestBase.index_name
+      assert_equal "test_bases", TestBase.new.index_name
+    end
+
+    should "return the explicit index_name" do
+      assert_equal "mammals", Animal.index_name
+      assert_equal "mammals", Animal.new.index_name
+    end
+
+    should "return the ancestor index_name" do
+      assert_equal "mammals", Dog.index_name
+      assert_equal "mammals", Dog.new.index_name
+    end
+
+    should "return the ancestor index_name for namespaced model" do
+      assert_equal "mammals", ::MyNamespace::Dog.index_name
+      assert_equal "mammals", ::MyNamespace::Dog.new.index_name
+    end
+
+    should "return the default document_type" do
+      assert_equal "test_base", TestBase.document_type
+      assert_equal "test_base", TestBase.new.document_type
+    end
+
+    should "return the explicit document_type" do
+      assert_equal "mammal", Animal.document_type
+      assert_equal "mammal", Animal.new.document_type
+    end
+
+    should "return the ancestor document_type" do
+      assert_equal "mammal", Dog.document_type
+      assert_equal "mammal", Dog.new.document_type
+    end
+
+    should "return the ancestor document_type for namespaced model" do
+      assert_equal "mammal", ::MyNamespace::Dog.document_type
+      assert_equal "mammal", ::MyNamespace::Dog.new.document_type
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for inheriting `index_name` and `document_type` on an opt-in basis:

```ruby
# within an initializer
Elasticsearch::Model.inheritance_enabled = true

class Animal < ActiveRecord::Base
  document_type 'mammal'
  index_name 'mammals'
end

class Dog < Animal
end

Animal.document_type   # 'mammal'
Animal.index_name      # 'mammals'
Dog.document_type      # 'mammal'
Dog.index_name         # 'mammals'
```

We wrap all our models exposed through our api in an `Api::` wrapper that helps us handle versioning issues.  Without support for inherited values it's easy to forget to add the explicit values to the subclasses, or update them if the base class ever changed.

Related to https://github.com/elasticsearch/elasticsearch-rails/issues/28 and https://github.com/elasticsearch/elasticsearch-rails/issues/92. Not sure it's enough for https://github.com/elasticsearch/elasticsearch-rails/issues/170.