### PR TITLE
Force no_timeout in mongoid adapter

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
@@ -66,7 +66,7 @@ module Elasticsearch
             options[:batch_size] ||= 1_000
             items = []
 
-            all.each do |item|
+            all.no_timeout.each do |item|
               items << item
 
               if items.length % options[:batch_size] == 0


### PR DESCRIPTION
I can't index without no_timeout. Indexation of my model takes 5 hours.