### PR TITLE
Save pre-saved changed_attributes.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -59,8 +59,9 @@ module Elasticsearch
           # @see http://api.rubyonrails.org/classes/ActiveModel/Dirty.html
           #
           before_save do |i|
+            changed_attr = i.__elasticsearch__.instance_variable_get(:@__changed_attributes) || Hash[]
             i.__elasticsearch__.instance_variable_set(:@__changed_attributes,
-                                                      Hash[ i.changes.map { |key, value| [key, value.last] } ])
+                                                      changed_attr.merge(Hash[ i.changes.map { |key, value| [key, value.last] } ]))
           end if respond_to?(:before_save) && instance_methods.include?(:changed_attributes)
         end
       end

--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -11,6 +11,7 @@ module Elasticsearch
           ActiveRecord::Schema.define(:version => 1) do
             create_table :articles do |t|
               t.string   :title
+              t.string   :body
               t.datetime :created_at, :default => 'NOW()'
             end
           end
@@ -22,6 +23,7 @@ module Elasticsearch
             settings index: { number_of_shards: 1, number_of_replicas: 0 } do
               mapping do
                 indexes :title,      type: 'string', analyzer: 'snowball'
+                indexes :body,       type: 'string'
                 indexes :created_at, type: 'date'
               end
             end
@@ -30,9 +32,9 @@ module Elasticsearch
           Article.delete_all
           Article.__elasticsearch__.create_index! force: true
 
-          ::Article.create! title: 'Test'
-          ::Article.create! title: 'Testing Coding'
-          ::Article.create! title: 'Coding'
+          ::Article.create! title: 'Test',           body: ''
+          ::Article.create! title: 'Testing Coding', body: ''
+          ::Article.create! title: 'Coding',         body: ''
 
           Article.__elasticsearch__.refresh_index!
         end
@@ -142,6 +144,29 @@ module Elasticsearch
 
           response = Article.search 'title:special'
 
+          assert_equal 1, response.results.size
+          assert_equal 1, response.records.size
+        end
+
+        should "update for multiple save in transaction" do
+          article = Article.first
+          response = Article.search 'body:dummy'
+
+          assert_equal 0, response.results.size
+          assert_equal 0, response.records.size
+
+          ActiveRecord::Base.transaction do
+            article.body = 'dummy'
+            article.save
+
+            article.title = 'special'
+            article.save
+          end
+
+          article.__elasticsearch__.update_document
+          Article.__elasticsearch__.refresh_index!
+
+          response = Article.search 'body:dummy'
           assert_equal 1, response.results.size
           assert_equal 1, response.records.size
         end


### PR DESCRIPTION
Hi!

I use `update_document` method in `after_commit` for transaction. In a controller, if we call `save` method twice or more times in `transaction` block, `before_save` overwrites `@__changed_attributes` variable. So elasticsearch does not reflect entire changes.

So I tried to keep the variable before overwrite.