### PR TITLE
[STORE] allowed the updated_at timestamp to persist to the database upon...

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
@@ -53,9 +53,9 @@ module Elasticsearch
               options.update index: self._index if self._index
               options.update type:  self._type  if self._type
 
-              response = self.class.gateway.save(self, options)
-
               self[:updated_at] = Time.now.utc
+
+              response = self.class.gateway.save(self, options)
 
               @_id       = response['_id']
               @_index    = response['_index']


### PR DESCRIPTION
Because the `updated_at` timestamping happens after the save, `self[:updated_at]` is only applying an `updated_at` timestamp to the model in memory, and not actually persisting that timestamp to the database. So it seems that the order of these lines needs to be flipped, with the `gateway.save` happening second, which will actually persist the `updated_at` change to the database. This would be more consistent with the `update` and `touch` methods which do actually persist the change.
