### PR TITLE
Use parent's index_name and document_type from child models

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/naming.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/naming.rb
@@ -34,7 +34,7 @@ module Elasticsearch
           if @index_name.respond_to?(:call)
             @index_name.call
           else
-            @index_name || self.model_name.collection.gsub(/\//, '-')
+            @index_name || self.base_model_name.collection.gsub(/\//, '-')
           end
         end
 
@@ -58,7 +58,7 @@ module Elasticsearch
         #     Article.document_type "my-article"
         #
         def document_type name=nil
-          @document_type = name || @document_type || self.model_name.element
+          @document_type = name || @document_type || self.base_model_name.element
         end
 
 
@@ -68,6 +68,13 @@ module Elasticsearch
         #
         def document_type=(name)
           @document_type = name
+        end
+
+        private
+
+        # Get the base class's model_name
+        def base_model_name
+          respond_to?(:base_class) ? base_class.model_name : model_name
         end
       end
 


### PR DESCRIPTION
Suppose there are three models:

``` rb
class Company < ActiveRecord::Base
  include Elasticsearch::Model
end
class TechCompany < Company; end
class TradingCompany < Company; end
```

then previously they respond to "document_type" as follows:

``` rb
Company.document_type        #=> 'company'
TechCompany.document_type    #=> 'tech_company'
TradingCompany.document_type #=> 'trading_company'
```

This commit changes them as:

``` rb
Company.document_type        #=> 'company'
TechCompany.document_type    #=> 'company'
TradingCompany.document_type #=> 'company'
```

So, we can use search scope like this:

``` rb
Company.search('*')  # Returns both TechCompany and TradingCompany

# Make `TechCompany.search` automatically add a filter such as
# `{ must: { term: { type: 'TechCompany' } } }`
TechCompany.search('*')  # Returns TechCompany only
```
