### PR TITLE
[MODEL] Support for querying multiple models

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -172,6 +172,12 @@ response.results.first._source.title
 # => "Quick brown fox"
 ```
 
+Or if we want to perform the search across different models:
+
+```ruby
+Elasticsearch::Model.search 'fox dogs', [Article, Comment]
+```
+
 #### Search results
 
 The returned `response` object is a rich wrapper around the JSON returned from Elasticsearch,
@@ -216,7 +222,17 @@ response.records.to_a
 ```
 
 The returned object is the genuine collection of model instances returned by your database,
-i.e. `ActiveRecord::Relation` for ActiveRecord, or `Mongoid::Criteria` in case of MongoDB. This allows you to
+i.e. `ActiveRecord::Relation` for ActiveRecord, or `Mongoid::Criteria` in case of MongoDB.
+When the search is performed across different models, an Array of model instances is returned.
+
+```ruby
+Elasticsearch::Model.search('fox', [Article, Comment]).records
+# Article Load (0.3ms)  SELECT "articles".* FROM "articles" WHERE "articles"."id" IN (1)
+# Comment Load (0.2ms)  SELECT "comments".* FROM "comments" WHERE "comments"."id" IN (1,5)
+# => [#<Article id: 1, title: "Quick brown fox">, #<Comment id: 1, body: "I like foxes">,  #<Comment id: 5, body: "Michael J.Fox is my favorite actor">]
+```
+
+In the case of searching a single model, this allows you to
 chain other methods on top of search results, as you would normally do:
 
 ```ruby

--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -70,7 +70,7 @@ module Elasticsearch
 
     # Keeps a registry of the classes that include `Elasticsearch::Model`
     #
-    class Registry < Array
+    class Registry
 
       # Add the class of a model to the registry
       #

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -7,7 +7,7 @@ module Elasticsearch
       module ActiveRecord
 
         Adapter.register self,
-                         lambda { |klass| !!defined?(::ActiveRecord::Base) && klass.ancestors.include?(::ActiveRecord::Base) }
+                         lambda { |klass| !!defined?(::ActiveRecord::Base) && klass.respond_to?(:ancestors) && klass.ancestors.include?(::ActiveRecord::Base) }
 
         module Records
           # Returns an `ActiveRecord::Relation` instance

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
@@ -9,7 +9,7 @@ module Elasticsearch
       module Mongoid
 
         Adapter.register self,
-                         lambda { |klass| !!defined?(::Mongoid::Document) && klass.ancestors.include?(::Mongoid::Document) }
+                         lambda { |klass| !!defined?(::Mongoid::Document) && klass.respond_to?(:ancestors) && klass.ancestors.include?(::Mongoid::Document) }
 
         module Records
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -97,6 +97,10 @@ module Elasticsearch
           # A simple class-level memoization over the `_index` and `_type` properties of the hit is applied.
           # Hence querying the Model Registry is done the minimal amount of times.
           #
+          # Event though memoization happens at the class level, the side effect of a race condition will only be
+          # to iterate over models one extra time, so we can consider the method thread-safe, and don't include
+          # any Mutex.synchronize around the method implementaion
+          #
           # @see Elasticsearch::Model::Registry
           #
           # @return Class
@@ -106,7 +110,7 @@ module Elasticsearch
           def __type(hit)
             @@__types ||= {}
             @@__types[[hit[:_index], hit[:_type]].join("::")] ||= begin
-              Registry.all.detect { |model| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
+              models.detect { |model| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
             end
           end
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -110,7 +110,7 @@ module Elasticsearch
           def __type(hit)
             @@__types ||= {}
             @@__types[[hit[:_index], hit[:_type]].join("::")] ||= begin
-              models.detect { |model| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
+              Registry.all.detect { |model| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
             end
           end
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -1,0 +1,125 @@
+module Elasticsearch
+  module Model
+    module Adapter
+
+      # An adapter to be used for deserializing results from multiple models, retrieved through
+      # Elasticsearch::Model.search
+      #
+      # @see Elasticsearch::Model.search
+      #
+      module Multiple
+
+        Adapter.register self, lambda { |klass| klass.is_a? Multimodel }
+
+        module Records
+
+          # Returns an Array, which elements are the model instances represented
+          # by the search results.
+          #
+          # This means that if the models queried are a Mixture of ActiveRecord, Mongoid, or
+          # POROs, the elements contained in this array will also be instances of those models
+          #
+          # Ranking of results across multiple indexes is preserved, and queries made to the different
+          # model's datasources are minimal.
+          #
+          # Internally, it gets the results, as ranked by elasticsearch.
+          # Then results are grouped by _type
+          # Then the model corresponding to each _type is queried to retrieve the records
+          # Finally records are rearranged in the same way results were ranked.
+          #
+          # @return [ElasticSearch::Model]
+          #
+          def records
+            @_records ||= begin
+              result = []
+              by_type = __records_by_type
+              __hits.each do |hit|
+                result << by_type[__type(hit)][hit[:_id]]
+              end
+              result.compact
+            end
+          end
+
+          # Returns the record representation of the results retrieved from Elasticsearch, grouped
+          # by model type
+          #
+          # @example
+          # {Series  =>
+          #   {"1"=> #<Series id: 1, series_name: "The Who S01", created_at: "2015-02-23 17:18:28">},
+          #
+          # "Title =>
+          #   {"1"=> #<Title id: 1, name: "Who Strikes Back", created_at: "2015-02-23 17:18:28">}}
+          #
+          # @api private
+          #
+          def __records_by_type
+            array = __ids_by_type.map do |klass, ids|
+              records = __type_records(klass, ids)
+              ids = records.map(&:id).map(&:to_s)
+              [klass, Hash[ids.zip(records)]]
+            end
+            Hash[array]
+          end
+
+          # Returns the records for a specific type
+          #
+          # @api private
+          #
+          def __type_records(klass, ids)
+            if (adapter = Adapter.adapters[ActiveRecord]) && adapter.call(klass)
+              klass.where(klass.primary_key => ids)
+            elsif (adapter = Adapter.adapters[Mongoid]) && adapter.call(klass)
+              klass.where(:id.in => ids)
+            else
+              klass.find(ids)
+            end
+          end
+
+
+          # @return A Hash containing for each type, the ids to retrieve
+          #
+          # @example {Series =>["1"], Title =>["1", "5"]}
+          #
+          # @api private
+          #
+          def __ids_by_type
+            ids_by_type = {}
+            __hits.each do |hit|
+              type = __type(hit)
+              ids_by_type[type] ||= []
+              ids_by_type[type] << hit[:_id]
+            end
+            ids_by_type
+          end
+
+          # Returns the class of the model associated to a certain hit
+          #
+          # A simple class-level memoization over the `_index` and `_type` properties of the hit is applied.
+          # Hence querying the Model Registry is done the minimal amount of times.
+          #
+          # @see Elasticsearch::Model::Registry
+          #
+          # @return Class
+          #
+          # @api private
+          #
+          def __type(hit)
+            @@__types ||= {}
+            @@__types[[hit[:_index], hit[:_type]].join("::")] ||= begin
+              Registry.all.detect { |model| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
+            end
+          end
+
+
+          # Memoizes and returns the hits from the response
+          #
+          # @api private
+          #
+          def __hits
+            @__hits ||= response.response["hits"]["hits"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -1,0 +1,43 @@
+module Elasticsearch
+  module Model
+
+    # Wraps a series of models to be used when querying multiple indexes via Elasticsearch::Model.search
+    #
+    # @see Elasticsearch::Model.search
+    #
+    class Multimodel
+
+      attr_reader :models
+
+      # @param models [Class] The list of models across which the search will be performed.
+      def initialize(*models)
+        @models = models.flatten
+        @models = Model::Registry.all if @models.empty?
+      end
+
+      # Get the list of index names used for retrieving documents when doing a search across multiple models
+      #
+      # @return [String] the list of index names used for retrieving documents
+      #
+      def index_name
+        models.map { |m| m.index_name }
+      end
+
+      # Get the list of document types used for retrieving documents when doing a search across multiple models
+      #
+      # @return [String] the list of document types used for retrieving documents
+      #
+      def document_type
+        models.map { |m| m.document_type }
+      end
+
+      # Get the client common for all models
+      #
+      # @return Elasticsearch::Transport::Client
+      #
+      def client
+        Elasticsearch::Model.client
+      end
+    end
+  end
+end

--- a/elasticsearch-model/test/integration/multiple_models_test.rb
+++ b/elasticsearch-model/test/integration/multiple_models_test.rb
@@ -1,0 +1,156 @@
+require 'test_helper'
+require 'active_record'
+
+Mongo.setup!
+
+module Elasticsearch
+  module Model
+    class MultipleModelsIntegraton < Elasticsearch::Test::IntegrationTestCase
+      context "Multiple models" do
+        setup do
+          ActiveRecord::Schema.define(:version => 1) do
+            create_table :episodes do |t|
+              t.string :name
+              t.datetime :created_at, :default => 'NOW()'
+            end
+
+            create_table :series do |t|
+              t.string :name
+              t.datetime :created_at, :default => 'NOW()'
+            end
+          end
+
+          class ::Episode < ActiveRecord::Base
+            include Elasticsearch::Model
+            include Elasticsearch::Model::Callbacks
+
+            settings index: {number_of_shards: 1, number_of_replicas: 0} do
+              mapping do
+                indexes :name, type: 'string', analyzer: 'snowball'
+                indexes :created_at, type: 'date'
+              end
+            end
+          end
+
+          class ::Series < ActiveRecord::Base
+            include Elasticsearch::Model
+            include Elasticsearch::Model::Callbacks
+
+            settings index: {number_of_shards: 1, number_of_replicas: 0} do
+              mapping do
+                indexes :name, type: 'string', analyzer: 'snowball'
+                indexes :created_at, type: 'date'
+              end
+            end
+          end
+
+          [::Episode, ::Series].each do |model|
+            model.delete_all
+            model.__elasticsearch__.create_index! force: true
+            model.create name: "The #{model.name}"
+            model.create name: "A great #{model.name}"
+            model.create name: "The greatest #{model.name}"
+            model.__elasticsearch__.refresh_index!
+          end
+
+        end
+
+        should "find matching documents across multiple models" do
+          response = Elasticsearch::Model.search("greatest", [Series, Episode])
+
+          assert response.any?, "Response should not be empty: #{response.to_a.inspect}"
+
+          assert_equal 2, response.results.size
+          assert_equal 2, response.records.size
+
+          assert_instance_of Elasticsearch::Model::Response::Result, response.results.first
+          assert_instance_of Episode, response.records.first
+          assert_instance_of Series, response.records.last
+
+          assert_equal 'The greatest Episode', response.results[0].name
+          assert_equal 'The greatest Episode', response.records[0].name
+
+          assert_equal 'The greatest Series', response.results[1].name
+          assert_equal 'The greatest Series', response.records[1].name
+        end
+
+        should "provide access to result" do
+          q = {query: {query_string: {query: 'A great *'}}, highlight: {fields: {name: {}}}}
+          response = Elasticsearch::Model.search(q, [Series, Episode])
+
+          first_result, second_result = *response.results
+
+          assert_equal 'A great Episode', first_result.name
+          assert_equal true, first_result.name?
+          assert_equal false, first_result.boo?
+          assert_equal true, first_result.highlight?
+          assert_equal true, first_result.highlight.name?
+          assert_equal false, first_result.highlight.boo?
+
+          assert_equal 'A great Series', second_result.name
+          assert_equal true, second_result.name?
+          assert_equal false, second_result.boo?
+          assert_equal true, second_result.highlight?
+          assert_equal true, second_result.highlight.name?
+          assert_equal false, second_result.highlight.boo?
+        end
+
+        if Mongo.available?
+          Mongo.connect_to 'mongoid_collections'
+
+          context "Across mongoid models" do
+            setup do
+              class ::Image
+                include Mongoid::Document
+                include Elasticsearch::Model
+                include Elasticsearch::Model::Callbacks
+
+                field :name, type: String
+                attr_accessible :name if respond_to? :attr_accessible
+
+                settings index: {number_of_shards: 1, number_of_replicas: 0} do
+                  mapping do
+                    indexes :name, type: 'string', analyzer: 'snowball'
+                    indexes :created_at, type: 'date'
+                  end
+                end
+
+                def as_indexed_json(options={})
+                  as_json(except: [:_id])
+                end
+              end
+
+              Image.delete_all
+              Image.__elasticsearch__.create_index! force: true
+              Image.create! name: "The Image"
+              Image.create! name: "A great Image"
+              Image.create! name: "The greatest Image"
+              Image.__elasticsearch__.refresh_index!
+              Image.__elasticsearch__.client.cluster.health wait_for_status: 'yellow'
+            end
+
+            should "find matching documents across multiple models" do
+              response = Elasticsearch::Model.search("greatest", [Episode, Image])
+
+              assert response.any?, "Response should not be empty: #{response.to_a.inspect}"
+
+              assert_equal 2, response.results.size
+              assert_equal 2, response.records.size
+
+              assert_instance_of Elasticsearch::Model::Response::Result, response.results.first
+              assert_instance_of Image, response.records.first
+              assert_instance_of Episode, response.records.last
+
+              assert_equal 'The greatest Image', response.results[0].name
+              assert_equal 'The greatest Image', response.records[0].name
+
+              assert_equal 'The greatest Episode', response.results[1].name
+              assert_equal 'The greatest Episode', response.records[1].name
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-model/test/test_helper.rb
+++ b/elasticsearch-model/test/test_helper.rb
@@ -61,3 +61,33 @@ module Elasticsearch
     end
   end
 end
+
+class Mongo
+  def self.setup!
+    begin
+      require 'mongoid'
+      session = Moped::Connection.new("localhost", 27017, 0.5)
+      session.connect
+      ENV['MONGODB_AVAILABLE'] = 'yes'
+    rescue LoadError, Moped::Errors::ConnectionFailure => e
+      $stderr.puts "MongoDB not installed or running: #{e}"
+    end
+  end
+
+  def self.available?
+    !!ENV['MONGODB_AVAILABLE']
+  end
+
+  def self.connect_to(source)
+    $stderr.puts "Mongoid #{Mongoid::VERSION}", '-'*80
+
+    logger = ::Logger.new($stderr)
+    logger.formatter = lambda { |s, d, p, m| " #{m.ansi(:faint, :cyan)}\n" }
+    logger.level = ::Logger::DEBUG
+
+    Mongoid.logger = logger unless ENV['QUIET']
+    Moped.logger   = logger unless ENV['QUIET']
+
+    Mongoid.connect_to source
+  end
+end

--- a/elasticsearch-model/test/unit/adapter_multiple_test.rb
+++ b/elasticsearch-model/test/unit/adapter_multiple_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+class Elasticsearch::Model::MultipleTest < Test::Unit::TestCase
+
+  context "Adapter multiple module" do
+
+    class ::DummyOne
+      include Elasticsearch::Model
+
+      index_name 'dummy'
+      document_type 'dummy_one'
+
+      def self.find(ids)
+        ids.map { |id| new(id) }
+      end
+
+      attr_reader :id
+
+      def initialize(id)
+        @id = id.to_i
+      end
+    end
+
+    module ::Namespace
+      class DummyTwo
+        include Elasticsearch::Model
+
+        index_name 'dummy'
+        document_type 'dummy_two'
+
+        def self.find(ids)
+          ids.map { |id| new(id) }
+        end
+
+        attr_reader :id
+
+        def initialize(id)
+          @id = id.to_i
+        end
+      end
+    end
+
+    class ::DummyTwo
+      include Elasticsearch::Model
+
+      index_name 'other_index'
+      document_type 'dummy_two'
+
+      def self.find(ids)
+        ids.map { |id| new(id) }
+      end
+
+      attr_reader :id
+
+      def initialize(id)
+        @id = id.to_i
+      end
+    end
+
+    HITS = [{_index: 'dummy',
+             _type: 'dummy_two',
+             _id: '2',
+            }, {
+              _index: 'dummy',
+              _type: 'dummy_one',
+              _id: '2',
+            }, {
+              _index: 'other_index',
+              _type: 'dummy_two',
+              _id: '1',
+            }, {
+              _index: 'dummy',
+              _type: 'dummy_two',
+              _id: '1',
+            }, {
+              _index: 'dummy',
+              _type: 'dummy_one',
+              _id: '3'}]
+
+    setup do
+      @multimodel = Elasticsearch::Model::Multimodel.new(DummyOne, DummyTwo, Namespace::DummyTwo)
+    end
+
+    context "Records" do
+      setup do
+        @multimodel.class.send :include, Elasticsearch::Model::Adapter::Multiple::Records
+        @multimodel.expects(:__hits).at_least_once.returns(HITS)
+      end
+
+      should "keep global order among models" do
+        assert_instance_of Module, Elasticsearch::Model::Adapter::Multiple::Records
+        records = @multimodel.records
+
+        assert_equal 5, records.count
+
+        assert_kind_of ::Namespace::DummyTwo, records[0]
+        assert_kind_of ::DummyOne,            records[1]
+        assert_kind_of ::DummyTwo,            records[2]
+        assert_kind_of ::Namespace::DummyTwo, records[3]
+        assert_kind_of ::DummyOne,            records[4]
+
+        assert_equal [2, 2, 1, 1, 3], records.map(&:id)
+      end
+    end
+  end
+end

--- a/elasticsearch-model/test/unit/multimodel_test.rb
+++ b/elasticsearch-model/test/unit/multimodel_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class Elasticsearch::Model::MultimodelTest < Test::Unit::TestCase
+
+  context "Multimodel class" do
+    setup do
+      title  = stub('Title',  index_name: 'titles_index', document_type: 'title')
+      series = stub('Series', index_name: 'series_index', document_type: 'series')
+      @multimodel = Elasticsearch::Model::Multimodel.new(title, series)
+    end
+
+    should "#index_name" do
+      assert_equal ['titles_index', 'series_index'], @multimodel.index_name
+    end
+
+    should "#document_type" do
+      assert_equal ['title', 'series'], @multimodel.document_type
+    end
+
+    should "#client" do
+      assert_equal Elasticsearch::Model.client, @multimodel.client
+    end
+
+    should "default intialization" do
+      class ::JustAModel
+        include Elasticsearch::Model
+
+        document_type "just_a_model"
+      end
+
+      class ::JustAnotherModel
+        include Elasticsearch::Model
+
+        document_type "just_another_model"
+      end
+
+      multimodel = Elasticsearch::Model::Multimodel.new
+      assert multimodel.models.include?(::JustAModel)
+      assert multimodel.models.include?(::JustAnotherModel)
+    end
+  end
+end

--- a/elasticsearch-rails/test/unit/instrumentation/lograge_test.rb
+++ b/elasticsearch-rails/test/unit/instrumentation/lograge_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 require 'rails/railtie'
+require 'action_pack'
 require 'lograge'
 
 require 'elasticsearch/rails/lograge'


### PR DESCRIPTION
This PR adds support for multiple models search, as discussed in:
- https://github.com/elastic/elasticsearch-rails/issues/10
- https://github.com/elastic/elasticsearch-rails/issues/30 
- https://github.com/elastic/elasticsearch-rails/issues/50

A previous attempt of implementing this was done in:
- https://github.com/elastic/elasticsearch-rails/pull/129

But although the PR is open, it was rejected mainly due to:
- Lack of documentation
- Missing unit and integration tests
- An inconsistent Search response API: Even though `#results` was part of the *multimodel-search* response, `#records` was not.

This PR tries to address the problems outlined above, and also implement a performant hit-to-record deserialization.

Thank you very much to @AaronRustad [for his PR](https://github.com/elastic/elasticsearch-rails/pull/129), which motivated this one.

