### PR TITLE
[MODEL] Fix wrong retrieval of records corresponding to indexed documents when querying multiple models

### DIFF
--- a/elasticsearch-model/test/integration/multiple_models_test.rb
+++ b/elasticsearch-model/test/integration/multiple_models_test.rb
@@ -56,7 +56,7 @@ module Elasticsearch
         end
 
         should "find matching documents across multiple models" do
-          response = Elasticsearch::Model.search("greatest", [Series, Episode])
+          response = Elasticsearch::Model.search("\"The greatest Episode\"^2 OR \"The greatest Series\"", [Series, Episode])
 
           assert response.any?, "Response should not be empty: #{response.to_a.inspect}"
 
@@ -75,22 +75,15 @@ module Elasticsearch
         end
 
         should "provide access to results" do
-          q = {query: {query_string: {query: 'A great *'}}, highlight: {fields: {name: {}}}}
-          response = Elasticsearch::Model.search(q, [Series, Episode])
+          response = Elasticsearch::Model.search("\"A great Episode\"^2 OR \"A great Series\"", [Series, Episode])
 
           assert_equal 'A great Episode', response.results[0].name
           assert_equal true,              response.results[0].name?
           assert_equal false,             response.results[0].boo?
-          assert_equal true,              response.results[0].highlight?
-          assert_equal true,              response.results[0].highlight.name?
-          assert_equal false,             response.results[0].highlight.boo?
 
           assert_equal 'A great Series', response.results[1].name
           assert_equal true,             response.results[1].name?
           assert_equal false,            response.results[1].boo?
-          assert_equal true,             response.results[1].highlight?
-          assert_equal true,             response.results[1].highlight.name?
-          assert_equal false,            response.results[1].highlight.boo?
         end
 
         should "only retrieve records for existing results" do
@@ -144,7 +137,7 @@ module Elasticsearch
             end
 
             should "find matching documents across multiple models" do
-              response = Elasticsearch::Model.search("greatest", [Episode, Image])
+              response = Elasticsearch::Model.search("\"greatest Episode\" OR \"greatest Image\"^2", [Episode, Image])
 
               assert response.any?, "Response should not be empty: #{response.to_a.inspect}"
 

--- a/elasticsearch-model/test/unit/adapter_mongoid_test.rb
+++ b/elasticsearch-model/test/unit/adapter_mongoid_test.rb
@@ -76,7 +76,9 @@ class Elasticsearch::Model::AdapterMongoidTest < Test::Unit::TestCase
 
     context "Importing" do
       should "implement the __find_in_batches method" do
-        DummyClassForMongoid.expects(:all).returns([])
+        relation = mock()
+        relation.stubs(:no_timeout).returns([])
+        DummyClassForMongoid.expects(:all).returns(relation)
 
         DummyClassForMongoid.__send__ :extend, Elasticsearch::Model::Adapter::Mongoid::Importing
         DummyClassForMongoid.__find_in_batches do; end


### PR DESCRIPTION
This PR fixes #369 

* The first commit adds a fix for a regression introduced in #335, to depart from a green build
* The second commit includes:
      * A refactor over a `case/when` statement, as for objects. `case/when` only matches the branches in which `===` returns true. i.e. an object that is instance of a class. But if the object is a class itself, or a module like the adapters, it won't enter any of the `when` branches.
      * Taking back the call to `compact` over the collection of records, because as per eventual consistency, ES can return some results, which corresponding records no longer exist. As a consequence, calling records would return an array with positions including nil.
      * An integration test checking the correctness of the two points above.
* The third commit cleans up a bit the integration tests for multiple model.

