### PR TITLE
Model#save should persist updated_at timestamp

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -121,8 +121,8 @@ module Elasticsearch
 
           # Set up common attributes
           #
-          attribute :created_at, DateTime, default: lambda { |o,a| Time.now.utc }
-          attribute :updated_at, DateTime, default: lambda { |o,a| Time.now.utc }
+          attribute :created_at, Time, default: lambda { |o,a| Time.now.utc }
+          attribute :updated_at, Time, default: lambda { |o,a| Time.now.utc }
 
           attr_reader :hit
         end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
@@ -53,9 +53,9 @@ module Elasticsearch
               options.update index: self._index if self._index
               options.update type:  self._type  if self._type
 
-              response = self.class.gateway.save(self, options)
-
               self[:updated_at] = Time.now.utc
+
+              response = self.class.gateway.save(self, options)
 
               @_id       = response['_id']
               @_index    = response['_index']

--- a/elasticsearch-persistence/test/integration/model/model_basic_test.rb
+++ b/elasticsearch-persistence/test/integration/model/model_basic_test.rb
@@ -144,6 +144,20 @@ module Elasticsearch
           assert found.updated_at > updated_at, [found.updated_at, updated_at].inspect
         end
 
+        should 'update the object timestamp on save' do
+          person = Person.create name: 'John Smith'
+          person.admin = true
+          sleep 1
+          person.save
+
+          Person.gateway.refresh_index!
+
+          found = Person.find(person.id)
+
+          # Compare without usec
+          assert_equal found.updated_at.to_i, person.updated_at.to_i
+        end
+
         should "respect the version" do
           person = Person.create name: 'John Smith'
 


### PR DESCRIPTION
Without this PR, a persistence model will not actually save the updated_at timestamp to elasticsearch.

I've moved the change to the updated_at timestamp before the call to `gateway#save`.  Additionally, I've changed the `created_at` and `updated_at` timestamps to be a `Time` to more closely match how Rails deals with timestamps and to match how the code in store.rb is treating them.