### PR TITLE
Stop requiring empty block for mapping options

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -133,9 +133,9 @@ module Elasticsearch
         def mapping(options={}, &block)
           @mapping ||= Mappings.new(document_type, options)
 
-          if block_given?
-            @mapping.options.update(options)
+          @mapping.options.update(options) unless options.empty?
 
+          if block_given?
             @mapping.instance_eval(&block)
             return self
           else

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -106,8 +106,8 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
       end
 
       should "update and return the index mappings" do
-        DummyIndexingModel.mappings foo: 'boo' do; end
-        DummyIndexingModel.mappings bar: 'bam' do; end
+        DummyIndexingModel.mappings foo: 'boo'
+        DummyIndexingModel.mappings bar: 'bam'
         assert_equal( { dummy_indexing_model: { foo: "boo", bar: "bam", properties: {} } },
                       DummyIndexingModel.mappings.to_hash )
       end


### PR DESCRIPTION
This just bit me when trying to configure a class that includes Elasticsearch::Persistence::Model.  Since the attribute definitions handle setting up the mapping, I just wanted to set `dynamic` and `_routing`.  I had to resort to debugging to find out that I had to pass an empty block to get the `#mapping` method to actually do something with my options.