### PR TITLE
Fix timestamp tests

### DIFF
--- a/elasticsearch-persistence/test/integration/model/model_basic_test.rb
+++ b/elasticsearch-persistence/test/integration/model/model_basic_test.rb
@@ -135,7 +135,7 @@ module Elasticsearch
           person = Person.create name: 'John Smith'
           updated_at = person.updated_at
 
-          sleep 0.25
+          sleep 1
           person.touch
 
           assert person.updated_at > updated_at, [person.updated_at, updated_at].inspect
@@ -147,7 +147,7 @@ module Elasticsearch
         should 'update the object timestamp on save' do
           person = Person.create name: 'John Smith'
           person.admin = true
-          sleep 0.25
+          sleep 1
           person.save
 
           Person.gateway.refresh_index!


### PR DESCRIPTION
Until we have a version of rails that uses millisecond precision (>=4.1)
we have to wait an entire second to avoid race conditions.

See https://github.com/elastic/elasticsearch-rails/pull/395/files#diff-beb7964b74f717683049a9437a5570a2R1 for a breakdown on the differences in timestamp precision in different versions of rails.