### PR TITLE
[MODEL] Proper defaults for pagination in multimodel searches

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -48,11 +48,6 @@ module Elasticsearch
     class Multimodel
       attr_reader :models
 
-      # Kaminari configuration methods should be included at the instance level to
-      # let a multimodel instance be paginated with Kaminari.
-      #
-      include ::Kaminari::ConfigurationMethods::ClassMethods if defined? ::Kaminari
-      
       # @param models [Class] The list of models across which the search will be performed
       #
       def initialize(*models)

--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -48,6 +48,11 @@ module Elasticsearch
     class Multimodel
       attr_reader :models
 
+      # Kaminari configuration methods should be included at the instance level to
+      # let a multimodel instance be paginated with Kaminari.
+      #
+      include ::Kaminari::ConfigurationMethods::ClassMethods if defined? ::Kaminari
+      
       # @param models [Class] The list of models across which the search will be performed
       #
       def initialize(*models)

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -31,7 +31,7 @@ module Elasticsearch
                 @records  = nil
                 @response = nil
                 @page     = [num.to_i, 1].max
-                @per_page ||= klass.default_per_page
+                @per_page ||= __default_per_page
 
                 self.search.definition.update size: @per_page,
                                               from: @per_page * (@page - 1)
@@ -48,7 +48,7 @@ module Elasticsearch
               when search.definition[:size]
                 search.definition[:size]
               else
-                search.klass.default_per_page
+                __default_per_page
             end
           end
 
@@ -94,6 +94,14 @@ module Elasticsearch
           def total_count
             results.total
           end
+
+          # Returns the models's per_page or in case it doesn't exist (ex. Multimodel), Kaminari's default
+          #
+          # @api private
+          #
+          def __default_per_page
+            klass.respond_to?(:default_per_page) && klass.default_per_page || ::Kaminari.config.default_per_page
+          end
         end
 
         # Allow models to be paginated with the "will_paginate" gem [https://github.com/mislav/will_paginate]
@@ -126,7 +134,7 @@ module Elasticsearch
           def paginate(options)
             param_name = options[:param_name] || :page
             page       = [options[param_name].to_i, 1].max
-            per_page   = (options[:per_page] || klass.per_page).to_i
+            per_page   = (options[:per_page] || __default_per_page).to_i
 
             search.definition.update size: per_page,
                                      from: (page - 1) * per_page
@@ -167,6 +175,14 @@ module Elasticsearch
           #
           def total_entries
             results.total
+          end
+
+          # Returns the models's per_page or in case it doesn't exist (ex. Multimodel), WillPaginate's default
+          #
+          # @api private
+          #
+          def __default_per_page
+            klass.respond_to?(:per_page) && klass.per_page || ::WillPaginate.per_page
           end
         end
       end

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -1,16 +1,17 @@
 require 'test_helper'
 
 class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCase
+  class ModelClass
+    include ::Kaminari::ConfigurationMethods
+
+    def self.index_name;    'foo'; end
+    def self.document_type; 'bar'; end
+  end
+
+  RESPONSE = { 'took' => '5', 'timed_out' => false, '_shards' => {'one' => 'OK'},
+               'hits' => { 'total' => 100, 'hits' => (1..100).to_a.map { |i| { _id: i } } } }
+
   context "Response pagination" do
-    class ModelClass
-      include ::Kaminari::ConfigurationMethods
-
-      def self.index_name;    'foo'; end
-      def self.document_type; 'bar'; end
-    end
-
-    RESPONSE = { 'took' => '5', 'timed_out' => false, '_shards' => {'one' => 'OK'},
-                 'hits' => { 'total' => 100, 'hits' => (1..100).to_a.map { |i| { _id: i } } } }
 
     setup do
       @search   = Elasticsearch::Model::Searching::SearchRequest.new ModelClass, '*'
@@ -172,6 +173,183 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         @response.offset(35)
         @response.offset("asdf")
         assert_equal 0, @response.search.definition[:from]
+      end
+    end
+
+    context "total" do
+      should "return the number of hits" do
+        @response.expects(:results).returns(mock('results', total: 100))
+        assert_equal 100, @response.total_count
+      end
+    end
+
+    context "results" do
+      setup do
+        @search.stubs(:execute!).returns RESPONSE
+      end
+
+      should "return current page and total count" do
+        assert_equal 1, @response.page(1).results.current_page
+        assert_equal 100, @response.results.total_count
+
+        assert_equal 5, @response.page(5).results.current_page
+      end
+    end
+
+    context "records" do
+      setup do
+        @search.stubs(:execute!).returns RESPONSE
+      end
+
+      should "return current page and total count" do
+        assert_equal 1, @response.page(1).records.current_page
+        assert_equal 100, @response.records.total_count
+
+        assert_equal 5, @response.page(5).records.current_page
+      end
+    end
+  end
+
+  context "Multimodel response pagination" do
+    setup do
+      @multimodel = Elasticsearch::Model::Multimodel.new(ModelClass)
+      @search     = Elasticsearch::Model::Searching::SearchRequest.new @multimodel, '*'
+      @response   = Elasticsearch::Model::Response::Response.new @multimodel, @search, RESPONSE
+      @response.klass.stubs(:client).returns mock('client')
+    end
+
+    should "have pagination methods" do
+      assert_respond_to @response, :page
+      assert_respond_to @response, :limit_value
+      assert_respond_to @response, :offset_value
+      assert_respond_to @response, :limit
+      assert_respond_to @response, :offset
+      assert_respond_to @response, :total_count
+    end
+
+    context "#page method" do
+      should "advance the from/size" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal 25, definition[:from]
+          assert_equal 25, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        assert_nil @response.search.definition[:from]
+        assert_nil @response.search.definition[:size]
+
+        @response.page(2).to_a
+        assert_equal 25, @response.search.definition[:from]
+        assert_equal 25, @response.search.definition[:size]
+      end
+
+      should "advance the from/size further" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal 75, definition[:from]
+          assert_equal 25, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        @response.page(4).to_a
+        assert_equal 75, @response.search.definition[:from]
+        assert_equal 25, @response.search.definition[:size]
+      end
+    end
+
+    context "limit/offset readers" do
+      should "return the default" do
+        assert_equal Kaminari.config.default_per_page, @response.limit_value
+        assert_equal 0, @response.offset_value
+      end
+
+      should "return the value from URL parameters" do
+        search    = Elasticsearch::Model::Searching::SearchRequest.new ModelClass, '*', size: 10, from: 50
+        @response = Elasticsearch::Model::Response::Response.new ModelClass, search, RESPONSE
+
+        assert_equal 10, @response.limit_value
+        assert_equal 50, @response.offset_value
+      end
+
+      should "ignore the value from request body" do
+        search    = Elasticsearch::Model::Searching::SearchRequest.new ModelClass,
+                                                                       { query: { match_all: {} }, from: 333, size: 999 }
+        @response = Elasticsearch::Model::Response::Response.new ModelClass, search, RESPONSE
+
+        assert_equal Kaminari.config.default_per_page, @response.limit_value
+        assert_equal 0, @response.offset_value
+      end
+    end
+
+    context "limit setter" do
+      setup do
+        @response.records
+        @response.results
+      end
+
+      should "set the values" do
+        @response.limit(35)
+        assert_equal 35, @response.search.definition[:size]
+      end
+
+      should "reset the variables" do
+        @response.limit(35)
+
+        assert_nil @response.instance_variable_get(:@response)
+        assert_nil @response.instance_variable_get(:@records)
+        assert_nil @response.instance_variable_get(:@results)
+      end
+    end
+
+    context "with the page() and limit() methods" do
+      setup do
+        @response.records
+        @response.results
+      end
+
+      should "set the values" do
+        @response.page(3).limit(35)
+        assert_equal 35, @response.search.definition[:size]
+        assert_equal 70, @response.search.definition[:from]
+      end
+
+      should "set the values when limit is called first" do
+        @response.limit(35).page(3)
+        assert_equal 35, @response.search.definition[:size]
+        assert_equal 70, @response.search.definition[:from]
+      end
+
+      should "reset the instance variables" do
+        @response.page(3).limit(35)
+
+        assert_nil @response.instance_variable_get(:@response)
+        assert_nil @response.instance_variable_get(:@records)
+        assert_nil @response.instance_variable_get(:@results)
+      end
+    end
+
+    context "offset setter" do
+      setup do
+        @response.records
+        @response.results
+      end
+
+      should "set the values" do
+        @response.offset(15)
+        assert_equal 15, @response.search.definition[:from]
+      end
+
+      should "reset the variables" do
+        @response.offset(35)
+
+        assert_nil @response.instance_variable_get(:@response)
+        assert_nil @response.instance_variable_get(:@records)
+        assert_nil @response.instance_variable_get(:@results)
       end
     end
 

--- a/elasticsearch-model/test/unit/response_pagination_will_paginate_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_will_paginate_test.rb
@@ -3,24 +3,25 @@ require 'will_paginate'
 require 'will_paginate/collection'
 
 class Elasticsearch::Model::ResponsePaginationWillPaginateTest < Test::Unit::TestCase
+  class ModelClass
+    def self.index_name;    'foo'; end
+    def self.document_type; 'bar'; end
+
+    # WillPaginate adds this method to models (see WillPaginate::PerPage module)
+    def self.per_page
+      33
+    end
+  end
+
+  # Subsclass Response so we can include WillPaginate module without conflicts with Kaminari.
+  class WillPaginateResponse < Elasticsearch::Model::Response::Response
+    include Elasticsearch::Model::Response::Pagination::WillPaginate
+  end
+
+  RESPONSE = { 'took' => '5', 'timed_out' => false, '_shards' => {'one' => 'OK'},
+               'hits' => { 'total' => 100, 'hits' => (1..100).to_a.map { |i| { _id: i } } } }
+
   context "Response pagination" do
-    class ModelClass
-      def self.index_name;    'foo'; end
-      def self.document_type; 'bar'; end
-
-      # WillPaginate adds this method to models (see WillPaginate::PerPage module)
-      def self.per_page
-        33
-      end
-    end
-
-    # Subsclass Response so we can include WillPaginate module without conflicts with Kaminari.
-    class WillPaginateResponse < Elasticsearch::Model::Response::Response
-      include Elasticsearch::Model::Response::Pagination::WillPaginate
-    end
-
-    RESPONSE = { 'took' => '5', 'timed_out' => false, '_shards' => {'one' => 'OK'},
-                 'hits' => { 'total' => 100, 'hits' => (1..100).to_a.map { |i| { _id: i } } } }
 
     setup do
       @search   = Elasticsearch::Model::Searching::SearchRequest.new ModelClass, '*'
@@ -172,6 +173,183 @@ class Elasticsearch::Model::ResponsePaginationWillPaginateTest < Test::Unit::Tes
         @response.page(5)
         assert_equal 132, @response.search.definition[:from]
         assert_equal 33, @response.search.definition[:size]
+      end
+
+      should "set from/size when calling #page then #per_page" do
+        @response.page(5).per_page(3)
+        assert_equal 12, @response.search.definition[:from]
+        assert_equal 3, @response.search.definition[:size]
+      end
+
+      should "set from/size when calling #per_page then #page" do
+        @response.per_page(3).page(5)
+        assert_equal 12, @response.search.definition[:from]
+        assert_equal 3, @response.search.definition[:size]
+      end
+    end
+
+    context "#current_page method" do
+      should "return 1 by default" do
+        @response.paginate({})
+        assert_equal 1, @response.current_page
+      end
+
+      should "return current page number" do
+        @response.paginate(page: 3, per_page: 9)
+        assert_equal 3, @response.current_page
+      end
+
+      should "return nil if not pagination set" do
+        assert_equal nil, @response.current_page
+      end
+    end
+
+    context "#per_page method" do
+      should "return value set in paginate call" do
+        @response.paginate(per_page: 8)
+        assert_equal 8, @response.per_page
+      end
+    end
+
+    context "#total_entries method" do
+      should "return total from response" do
+        @response.expects(:results).returns(mock('results', total: 100))
+        assert_equal 100, @response.total_entries
+      end
+    end
+  end
+
+  context "Multimodel response pagination" do
+    setup do
+      @multimodel = Elasticsearch::Model::Multimodel.new ModelClass
+      @search      = Elasticsearch::Model::Searching::SearchRequest.new @multimodel, '*'
+      @response    = WillPaginateResponse.new @multimodel, @search, RESPONSE
+      @response.klass.stubs(:client).returns mock('client')
+
+      @expected_methods = [
+        # methods needed by WillPaginate::CollectionMethods
+        :current_page,
+        :offset,
+        :per_page,
+        :total_entries,
+        :length,
+
+        # methods defined by WillPaginate::CollectionMethods
+        :total_pages,
+        :previous_page,
+        :next_page,
+        :out_of_bounds?,
+      ]
+    end
+
+    should "have pagination methods" do
+      assert_respond_to @response, :paginate
+
+      @expected_methods.each do |method|
+        assert_respond_to @response, method
+      end
+    end
+
+    context "response.results" do
+      should "have pagination methods" do
+        @expected_methods.each do |method|
+          assert_respond_to @response.results, method
+        end
+      end
+    end
+
+    context "#offset method" do
+      should "calculate offset using current_page and per_page" do
+        @response.per_page(3).page(3)
+        assert_equal 6, @response.offset
+      end
+    end
+    context "#length method" do
+      should "return count of paginated results" do
+        @response.per_page(3).page(3)
+        assert_equal 3, @response.length
+      end
+    end
+
+    context "#paginate method" do
+      should "set from/size using WillPaginate defaults, ignoring aggregated models configuration" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal 0, definition[:from]
+          assert_equal ::WillPaginate.per_page, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        assert_nil @response.search.definition[:from]
+        assert_nil @response.search.definition[:size]
+
+        @response.paginate(page: nil).to_a
+        assert_equal 0, @response.search.definition[:from]
+        assert_equal ::WillPaginate.per_page, @response.search.definition[:size]
+      end
+
+      should "set from/size using default per_page, ignoring aggregated models' configuration" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal ::WillPaginate.per_page, definition[:from]
+          assert_equal ::WillPaginate.per_page, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        assert_nil @response.search.definition[:from]
+        assert_nil @response.search.definition[:size]
+
+        @response.paginate(page: 2).to_a
+        assert_equal ::WillPaginate.per_page, @response.search.definition[:from]
+        assert_equal ::WillPaginate.per_page, @response.search.definition[:size]
+      end
+
+      should "set from/size using custom page and per_page" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal 18, definition[:from]
+          assert_equal 9, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        assert_nil @response.search.definition[:from]
+        assert_nil @response.search.definition[:size]
+
+        @response.paginate(page: 3, per_page: 9).to_a
+        assert_equal 18, @response.search.definition[:from]
+        assert_equal 9, @response.search.definition[:size]
+      end
+
+      should "search for first page if specified page is < 1" do
+        @response.klass.client
+          .expects(:search)
+          .with do |definition|
+          assert_equal 0, definition[:from]
+          assert_equal ::WillPaginate.per_page, definition[:size]
+          true
+        end
+          .returns(RESPONSE)
+
+        assert_nil @response.search.definition[:from]
+        assert_nil @response.search.definition[:size]
+
+        @response.paginate(page: "-1").to_a
+        assert_equal 0, @response.search.definition[:from]
+        assert_equal ::WillPaginate.per_page, @response.search.definition[:size]
+      end
+    end
+
+    context "#page and #per_page shorthand methods" do
+      should "set from/size using default per_page" do
+        @response.page(5)
+        assert_equal 120, @response.search.definition[:from]
+        assert_equal ::WillPaginate.per_page, @response.search.definition[:size]
       end
 
       should "set from/size when calling #page then #per_page" do


### PR DESCRIPTION
This PR implements a fix for #382 

Due to the fact that different models aggregated on a multimodel search, could have different default values for the page size. I have opted for defaulting to Kaminari's and WillPaginate's respective default values.

I have included tests for ensuring correct pagination using both toolkits.