### PR TITLE
Add the ability to define how models are mapped to hits.

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -179,6 +179,30 @@ module Elasticsearch
         request = Searching::SearchRequest.new(models, query_or_payload, options)
         Response::Response.new(models, request)
       end
+
+      # Define a rule for mapping hits to models when searching across multiple models
+      #
+      # @param model_to_hit_selector [lambda(model,hit)] - Must return a boolean
+      #
+      # @example Map indices to models that operate against aliases
+      #
+      #     Elasticsearch::model_to_hit_selector = lambda do |model, hit|
+      #       /#{model.index_name}-.*/ =~ hit[:_index] && model.document_type == hit[:_type]
+      #     end
+      #
+      # @example Map indices to models but disregard the model's index name
+      #
+      #     Elasticsearch::model_to_hit_selector = lambda do |model, hit|
+      #       model.document_type == hit[:_type]
+      #     end
+      #
+      def model_to_hit_selector=(model_to_hit_selector)
+        @model_to_hit_selector = model_to_hit_selector
+      end
+
+      def model_to_hit_selector
+        @model_to_hit_selector ||= lambda { |model, hit| model.index_name == hit[:_index] && model.document_type == hit[:_type] }
+      end
     end
     extend ClassMethods
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -93,7 +93,7 @@ module Elasticsearch
 
             @@__types[ "#{hit[:_index]}::#{hit[:_type]}" ] ||= begin
               Registry.all.detect do |model|
-                model.index_name == hit[:_index] && model.document_type == hit[:_type]
+                Model.model_to_hit_selector.call(model, hit)
               end
             end
           end


### PR DESCRIPTION
This PR addresses https://github.com/elastic/elasticsearch-rails/issues/421

When searching against aliases, results from `Elasticsearch` are returned with the actual `_index` name rather than the alias name. The current implementation of Multiple Model Search uses the `_index` to determine which model to use. Unfortunately, when working with an aliased index, this mapping fails.

I don't think there is a 'correct' way to get around this, other than to give the user of the library the option of setting the logic for determining how to map indices to aliased models.

This PR gives the option of overriding the default `model` to `hit` selection code.

For example, in production, I'll use a timestamped index like `content-20150515164511'. 

``` ruby
# INITIALIZER
Elasticsearch::Model.model_to_hit_selector = lambda do |model,hit|
  /#{model.index_name}-.*/ =~ hit[:_index] && model.document_type == hit[:_type]
end
```
