### PR TITLE
[MODEL] a solution for the "undefined method `to_hash' for class `Elasticsearch::Model::Response::Result'" error

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -57,6 +57,10 @@ module Elasticsearch
         end
 
         # TODO: #to_s, #inspect, with support for Pry
+
+        def to_hash
+          @result.to_h
+        end
       end
     end
   end

--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -59,7 +59,8 @@ module Elasticsearch
         # TODO: #to_s, #inspect, with support for Pry
 
         #
-        # Returns the result object as a plain ruby hash to support pry's inspection
+        # Returns the result object as a plain ruby hash to support awesome_print benefits
+        # it allows invoking the Elasticsearch::Model::Response::Result#method(:to_hash) method
         #
         #
         # @return [Hash]

--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -58,6 +58,12 @@ module Elasticsearch
 
         # TODO: #to_s, #inspect, with support for Pry
 
+        #
+        # Returns the result object as a plain ruby hash to support pry's inspection
+        #
+        #
+        # @return [Hash]
+        #
         def to_hash
           @result.to_h
         end


### PR DESCRIPTION
This solution is related with the issue #430
