### PR TITLE
Remove extra level from jbuilder code.

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -329,9 +329,7 @@ require 'jbuilder'
 query = Jbuilder.encode do |json|
   json.query do
     json.match do
-      json.title do
-        json.query "fox dogs"
-      end
+      json.title "fox dogs"
     end
   end
 end

--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -100,6 +100,7 @@ module Elasticsearch
         #    Article.import return: 'errors'
         #
         def import(options={}, &block)
+          fail 'Import is unsafe when data is not in the SQL database'
           errors       = []
           refresh      = options.delete(:refresh)   || false
           target_index = options.delete(:index)     || index_name

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -400,8 +400,6 @@ module Elasticsearch
                 id:    self.id,
                 body:  { doc: attributes } }.merge(options)
             )
-          else
-            index_document(options)
           end
         end
 


### PR DESCRIPTION
The original jbuilder code produces:

``` json
{"query":{"match":{"title":{"query":"fox dogs"}}}}
```

And it actually should be:

``` json
{"query":{"match":{"title":"fox dogs"}}}
```
