### PR TITLE
Fix `next_page` method on Kaminari integration

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -20,8 +20,8 @@ module Elasticsearch
             Elasticsearch::Model::Response::Results.__send__ :include, ::Kaminari::PageScopeMethods
             Elasticsearch::Model::Response::Records.__send__ :include, ::Kaminari::PageScopeMethods
 
-            Elasticsearch::Model::Response::Results.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
-            Elasticsearch::Model::Response::Records.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
+            Elasticsearch::Model::Response::Results.__send__ :delegate, :limit_value, :offset_value, :total_count, :max_pages, to: :response
+            Elasticsearch::Model::Response::Records.__send__ :delegate, :limit_value, :offset_value, :total_count, :max_pages, to: :response
 
             base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               # Define the `page` Kaminari method

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -194,6 +194,17 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
 
         assert_equal 5, @response.page(5).results.current_page
       end
+
+      should "return previous page and next page" do
+        assert_equal nil, @response.page(1).results.prev_page
+        assert_equal 2, @response.page(1).results.next_page
+
+        assert_equal 3, @response.page(4).results.prev_page
+        assert_equal nil, @response.page(4).results.next_page
+
+        assert_equal 2, @response.page(3).results.prev_page
+        assert_equal 4, @response.page(3).results.next_page
+      end
     end
 
     context "records" do
@@ -206,6 +217,17 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         assert_equal 100, @response.records.total_count
 
         assert_equal 5, @response.page(5).records.current_page
+      end
+
+      should "return previous page and next page" do
+        assert_equal nil, @response.page(1).records.prev_page
+        assert_equal 2, @response.page(1).records.next_page
+
+        assert_equal 3, @response.page(4).records.prev_page
+        assert_equal nil, @response.page(4).records.next_page
+
+        assert_equal 2, @response.page(3).records.prev_page
+        assert_equal 4, @response.page(3).records.next_page
       end
     end
   end
@@ -371,6 +393,17 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
 
         assert_equal 5, @response.page(5).results.current_page
       end
+
+      should "return previous page and next page" do
+        assert_equal nil, @response.page(1).results.prev_page
+        assert_equal 2, @response.page(1).results.next_page
+
+        assert_equal 3, @response.page(4).results.prev_page
+        assert_equal nil, @response.page(4).results.next_page
+
+        assert_equal 2, @response.page(3).results.prev_page
+        assert_equal 4, @response.page(3).results.next_page
+      end
     end
 
     context "records" do
@@ -383,6 +416,17 @@ class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCas
         assert_equal 100, @response.records.total_count
 
         assert_equal 5, @response.page(5).records.current_page
+      end
+
+      should "return previous page and next page" do
+        assert_equal nil, @response.page(1).records.prev_page
+        assert_equal 2, @response.page(1).records.next_page
+
+        assert_equal 3, @response.page(4).records.prev_page
+        assert_equal nil, @response.page(4).records.next_page
+
+        assert_equal 2, @response.page(3).records.prev_page
+        assert_equal 4, @response.page(3).records.next_page
       end
     end
   end


### PR DESCRIPTION
Delegate `max_pages` to `Elasticsearch::Model::Response::Results` and `Elasticsearch::Model::Response::Response`, in order to  Kaminari method `next_page` work

The error:
```
> @records.next_page
NameError: undefined local variable or method `max_pages' for #<Elasticsearch::Model::Response::Records:0x007fb218974970>
from /Users/ggcampinho/.rvm/gems/ruby-2.2.2/gems/elasticsearch-model-0.1.7/lib/elasticsearch/model/response/records.rb:58:in `method_missing'
```