### PR TITLE
Add support for doc_as_upsert and scripted_upsert

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
@@ -51,18 +51,18 @@ module Elasticsearch
                  document_type || \
                  __get_type_from_class(klass)
 
+          body_params = [:doc, :script, :params, :upsert, :doc_as_upsert, :scripted_upsert]
           if defined?(serialized) && serialized
             body = if serialized[:script]
-                       serialized.select { |k, v| [:script, :params, :upsert].include? k }
+                       serialized.select { |k, v| body_params.include? k }
                      else
                        { doc: serialized }
                    end
           else
             body = {}
-            body.update( doc: options.delete(:doc)) if options[:doc]
-            body.update( script: options.delete(:script)) if options[:script]
-            body.update( params: options.delete(:params)) if options[:params]
-            body.update( upsert: options.delete(:upsert)) if options[:upsert]
+            body_params.each do |key|
+              body.update(key => options.delete(key)) if options[key]
+            end
           end
 
           client.update( { index: index_name, type: type, id: id, body: body }.merge(options) )

--- a/elasticsearch-persistence/test/unit/repository_store_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_store_test.rb
@@ -142,6 +142,22 @@ class Elasticsearch::Persistence::RepositoryStoreTest < Test::Unit::TestCase
         subject.update('1', script: 'ctx._source.foo += 1', upsert: { foo: 1 })
       end
 
+      should "get the ID from first argument and :script, :doc, :doc_as_upsert, and :scripted_upsert from document" do
+        subject.expects(:document_type).returns('mydoc')
+        subject.expects(:__extract_id_from_document).never
+
+        client = mock
+        client.expects(:update).with do |arguments|
+          assert_equal '1',     arguments[:id]
+          assert_equal 'mydoc', arguments[:type]
+          assert_equal({script: 'ctx._source.foo += 1', doc: { foo: 1 }, doc_as_upsert: true, scripted_upsert: true}, arguments[:body])
+          true
+        end
+        subject.expects(:client).returns(client)
+
+        subject.update('1', script: 'ctx._source.foo += 1', doc: { foo: 1 }, doc_as_upsert: true, scripted_upsert: true)
+      end
+
       should "get the ID and :doc from document" do
         subject.expects(:document_type).returns('mydoc')
 
@@ -185,6 +201,21 @@ class Elasticsearch::Persistence::RepositoryStoreTest < Test::Unit::TestCase
         subject.expects(:client).returns(client)
 
         subject.update(id: '1', script: 'ctx._source.foo += 1', upsert: { foo: 1 })
+      end
+
+      should "get the ID, :script, :doc, :doc_as_upsert, and :scripted_upsert from document" do
+        subject.expects(:document_type).returns('mydoc')
+
+        client = mock
+        client.expects(:update).with do |arguments|
+          assert_equal '1',     arguments[:id]
+          assert_equal 'mydoc', arguments[:type]
+          assert_equal({script: 'ctx._source.foo += 1', doc: { foo: 1 }, doc_as_upsert: true, scripted_upsert: true}, arguments[:body])
+          true
+        end
+        subject.expects(:client).returns(client)
+
+        subject.update(id: '1', script: 'ctx._source.foo += 1', doc: { foo: 1 }, doc_as_upsert: true, scripted_upsert: true)
       end
 
       should "override the type from params" do


### PR DESCRIPTION
You can't pass doc_as_upsert or scripted_upsert in body of update. -- copied from https://github.com/elastic/elasticsearch-ruby/issues/203
