### PR TITLE
[MODEL] Fixes searches with multiple models and aliases

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -93,7 +93,7 @@ module Elasticsearch
 
             @@__types[ "#{hit[:_index]}::#{hit[:_type]}" ] ||= begin
               Registry.all.detect do |model|
-                model.index_name == hit[:_index] && model.document_type == hit[:_type]
+                hit[:_index] =~ /#{model.index_name}/ && model.document_type == hit[:_type]
               end
             end
           end


### PR DESCRIPTION
It is typical for production environments to use index aliases
to simplify maintenance.

For example, if you had an index for the `Article` model, your index
could be named `articles1` and then you have an alias `articles` that
points to that index.

This way if you need to recreate your index without downtime, you can
create and populate another index called `articles2` and simply change
the alias when you are done.

The current code in the multiple adapter asumes the index name declared
in the model will match the one returned by elasticsearch in the hits response
but this is not the case. When using an alias, elasticsearch returns the
actual index name, not the alias.

What I am doing here is match the index name in the model and the index name
in the hit by prefix. So now the match happens even if the name of the index
has more characters after the name.

Meaning, if the index name defined in the model is `articles` and the
hit returns `articles999999` it will be a match and everything will be
allright.
