### PR TITLE
use rails logger instead of calling stout directly

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -248,7 +248,7 @@ When you want to access both the database `records` and search `results`, use th
 (or `map_with_hit`) iterator:
 
 ```ruby
-response.records.each_with_hit { |record, hit| puts "* #{record.title}: #{hit._score}" }
+response.records.each_with_hit { |record, hit| Rails.logger.info "* #{record.title}: #{hit._score}" }
 # * Quick brown fox: 0.02250402
 # * Fast black dogs: 0.02250402
 ```

--- a/elasticsearch-model/examples/activerecord_article.rb
+++ b/elasticsearch-model/examples/activerecord_article.rb
@@ -62,7 +62,7 @@ Article.__send__ :include, Elasticsearch::Model
 #   end
 # end
 
-puts '', '-'*Pry::Terminal.width!
+Rails.logger.debug '', '-'*Pry::Terminal.width!
 
 Elasticsearch::Model.client = Elasticsearch::Client.new log: true
 

--- a/elasticsearch-model/examples/activerecord_associations.rb
+++ b/elasticsearch-model/examples/activerecord_associations.rb
@@ -160,9 +160,9 @@ article.comments.create text: 'Second comment for article One'
 
 Elasticsearch::Model.client.indices.refresh index: Elasticsearch::Model::Registry.all.map(&:index_name)
 
-puts "\n\e[1mArticles containing 'one':\e[0m", Article.search('one').records.to_a.map(&:inspect), ""
+Rails.logger.info "\n\e[1mArticles containing 'one':\e[0m", Article.search('one').records.to_a.map(&:inspect), ""
 
-puts "\n\e[1mModels containing 'one':\e[0m", Elasticsearch::Model.search('one').records.to_a.map(&:inspect), ""
+Rails.logger.info "\n\e[1mModels containing 'one':\e[0m", Elasticsearch::Model.search('one').records.to_a.map(&:inspect), ""
 
 # Load model
 #
@@ -170,7 +170,8 @@ article = Article.all.includes(:categories, :authors, :comments).first
 
 # ----- Pry ---------------------------------------------------------------------------------------
 
-puts '', '-'*Pry::Terminal.width!
+Rails.logger.debug ''
+Rails.logger.debug '-'*Pry::Terminal.width!
 
 Pry.start(binding, prompt: lambda { |obj, nest_level, _| '> ' },
                    input: StringIO.new("article.as_indexed_json\n"),

--- a/elasticsearch-model/examples/activerecord_mapping_completion.rb
+++ b/elasticsearch-model/examples/activerecord_mapping_completion.rb
@@ -50,8 +50,8 @@ Article.__elasticsearch__.refresh_index!
 
 response_1 = Article.search 'foo';
 
-puts "Article search:".ansi(:bold),
-     response_1.to_a.map { |d| "Title: #{d.title}" }.inspect.ansi(:bold, :yellow)
+Rails.logger.info "Article search:".ansi(:bold)
+Rails.logger.info response_1.to_a.map { |d| "Title: #{d.title}" }.inspect.ansi(:bold, :yellow)
 
 response_2 = Article.__elasticsearch__.client.suggest \
   index: Article.index_name,
@@ -62,8 +62,8 @@ response_2 = Article.__elasticsearch__.client.suggest \
     }
   };
 
-puts "Article suggest:".ansi(:bold),
-     response_2['articles'].first['options'].map { |d| "#{d['text']} -> #{d['payload']['url']}" }.
-     inspect.ansi(:bold, :green)
+Rails.logger.info "Article suggest:".ansi(:bold)
+Rails.logger.info response_2['articles'].first['options'].map { |d| "#{d['text']} -> #{d['payload']['url']}" }.
+                    inspect.ansi(:bold, :green)
 
 require 'pry'; binding.pry;

--- a/elasticsearch-model/examples/ohm_article.rb
+++ b/elasticsearch-model/examples/ohm_article.rb
@@ -49,7 +49,7 @@ end
 #
 Elasticsearch::Model.client = Elasticsearch::Client.new log: true
 
-puts '', '-'*Pry::Terminal.width!
+Rails.logger.debug '', '-'*Pry::Terminal.width!
 
 Article.all.map { |a| a.delete }
 Article.create id: '1', title: 'Foo'

--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -49,7 +49,7 @@ module Elasticsearch
         # @example Process the response from Elasticsearch
         #
         #     Article.import do |response|
-        #       puts "Got " + response['items'].select { |i| i['index']['error'] }.size.to_s + " errors"
+        #       Rails.logger.error "Got " + response['items'].select { |i| i['index']['error'] }.size.to_s + " errors"
         #     end
         #
         # @example Delete and create the index with appropriate settings and mappings

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -265,7 +265,7 @@ module Elasticsearch
             self.client.indices.delete index: target_index
           rescue Exception => e
             if e.class.to_s =~ /NotFound/ && options[:force]
-              STDERR.puts "[!!!] Index does not exist (#{e.class})"
+              Rails.logger.error "[!!!] Index does not exist (#{e.class})"
             else
               raise e
             end
@@ -291,7 +291,7 @@ module Elasticsearch
             self.client.indices.refresh index: target_index
           rescue Exception => e
             if e.class.to_s =~ /NotFound/ && options[:force]
-              STDERR.puts "[!!!] Index does not exist (#{e.class})"
+              Rails.logger.error "[!!!] Index does not exist (#{e.class})"
             else
               raise e
             end

--- a/elasticsearch-persistence/README.md
+++ b/elasticsearch-persistence/README.md
@@ -143,7 +143,7 @@ repository = Elasticsearch::Persistence::Repository.new do
 
   # Customize the de-serialization logic
   def deserialize(document)
-    puts "# ***** CUSTOM DESERIALIZE LOGIC KICKING IN... *****"
+    Rails.logger.info "# ***** CUSTOM DESERIALIZE LOGIC KICKING IN... *****"
     super
   end
 end
@@ -241,7 +241,7 @@ note = Note.new 'id' => 1, 'text' => 'Document with image', 'image' => '... BINA
 repository.save(note)
 # PUT http://localhost:9200/notes_development/note/1
 # > {"id":1,"text":"Document with image","image":"Li4uIEJJTkFSWSBEQVRBIC4uLg==\n"}
-puts repository.find(1).attributes['image']
+Rails.logger.info repository.find(1).attributes['image']
 # GET http://localhost:9200/notes_development/note/1
 # < {... "_source" : { ... "image":"Li4uIEJJTkFSWSBEQVRBIC4uLg==\n"}}
 # => ... BINARY DATA ...
@@ -397,7 +397,7 @@ results = repository.search(query: { match: { title: 'fox dog' } })
 # Iterate over the objects
 #
 results.each do |note|
-  puts "* #{note.attributes[:title]}"
+  Rails.logger.info "* #{note.attributes[:title]}"
 end
 # * QUICK BROWN FOX
 # * FAST WHITE DOG
@@ -405,7 +405,7 @@ end
 # Iterate over the objects and hits
 #
 results.each_with_hit do |note, hit|
-  puts "* #{note.attributes[:title]}, score: #{hit._score}"
+  Rails.logger.info "* #{note.attributes[:title]}, score: #{hit._score}"
 end
 # * QUICK BROWN FOX, score: 0.29930896
 # * FAST WHITE DOG, score: 0.29930896
@@ -494,7 +494,7 @@ class Article
 
   # Execute code after saving the model.
   #
-  after_save { puts "Successfully saved: #{self}" }
+  after_save { Rails.logger.info "Successfully saved: #{self}" }
 end
 ```
 
@@ -580,7 +580,7 @@ The model also supports familiar `find_in_batches` and `find_each` methods to ef
 retrieve big collections of model instances, using the Elasticsearch's _Scan API_:
 
 ```ruby
-Article.find_each(_source_include: 'title') { |a| puts "===> #{a.title.upcase}" }
+Article.find_each(_source_include: 'title') { |a| Rails.logger.info "===> #{a.title.upcase}" }
 # GET http://localhost:9200/articles/article/_search?scroll=5m&search_type=scan&size=20
 # GET http://localhost:9200/_search/scroll?scroll=5m&scroll_id=c2Nhb...
 # ===> TEST
@@ -598,13 +598,13 @@ results = Article.search query: { match: { title: 'test' } },
                          aggregations: {  authors: { terms: { field: 'author.raw' } } },
                          highlight: { fields: { title: {} } }
 
-puts results.first.title
+Rails.logger.info results.first.title
 # Test
 
-puts results.first.hit.highlight['title']
+Rails.logger.info results.first.hit.highlight['title']
 # <em>Test</em>
 
-puts results.response.aggregations.authors.buckets.each { |b| puts "#{b['key']} : #{b['doc_count']}" }
+Rails.logger.info results.response.aggregations.authors.buckets.each { |b| Rails.logger.info "#{b['key']} : #{b['doc_count']}" }
 # John : 1
 ```
 

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/find.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/find.rb
@@ -69,19 +69,19 @@ module Elasticsearch
           #
           # @example Return all models in batches of 20 x number of primary shards
           #
-          #     Person.find_in_batches { |batch| puts batch.map(&:name) }
+          #     Person.find_in_batches { |batch| Rails.logger.info batch.map(&:name) }
           #
           # @example Return all models in batches of 100 x number of primary shards
           #
-          #     Person.find_in_batches(size: 100) { |batch| puts batch.map(&:name) }
+          #     Person.find_in_batches(size: 100) { |batch| Rails.logger.info batch.map(&:name) }
           #
           # @example Return all models matching a specific query
           #
-          #      Person.find_in_batches(query: { match: { name: 'test' } }) { |batch| puts batch.map(&:name) }
+          #      Person.find_in_batches(query: { match: { name: 'test' } }) { |batch| Rails.logger.info batch.map(&:name) }
           #
           # @example Return all models, fetching only the `name` attribute from Elasticsearch
           #
-          #      Person.find_in_batches( _source_include: 'name') { |_| puts _.response.hits.hits.map(&:to_hash) }
+          #      Person.find_in_batches( _source_include: 'name') { |_| Rails.logger.info _.response.hits.hits.map(&:to_hash) }
           #
           # @example Leave out the block to return an Enumerator instance
           #
@@ -147,7 +147,7 @@ module Elasticsearch
           #
           # @example Print out the people's names by scrolling through the index
           #
-          #     Person.find_each { |person| puts person.name }
+          #     Person.find_each { |person| Rails.logger.info person.name }
           #
           #     # # GET http://localhost:9200/people/person/_search?scroll=5m&search_type=scan&size=20
           #     # # GET http://localhost:9200/_search/scroll?scroll=5m&scroll_id=c2Nhbj...

--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -42,7 +42,11 @@ namespace :elasticsearch do
     desc import_model_desc
     task :model do
       if ENV['CLASS'].to_s == ''
-        puts '='*90, 'USAGE', '='*90, import_model_desc, ""
+        Rails.logger.info '='*90
+        Rails.logger.info 'USAGE'
+        Rails.logger.info '='*90
+        Rails.logger.info import_model_desc
+        Rails.logger.info ''
         exit(1)
       end
 
@@ -71,8 +75,8 @@ namespace :elasticsearch do
       end
       pbar.finish if pbar
 
-      puts "[IMPORT] #{total_errors} errors occurred" unless total_errors.zero?
-      puts '[IMPORT] Done'
+      Rails.logger.error "[IMPORT] #{total_errors} errors occurred" unless total_errors.zero?
+      Rails.logger.info '[IMPORT] Done'
     end
 
     desc <<-DESC.gsub(/    /, '')
@@ -83,7 +87,7 @@ namespace :elasticsearch do
     task :all do
       dir    = ENV['DIR'].to_s != '' ? ENV['DIR'] : Rails.root.join("app/models")
 
-      puts "[IMPORT] Loading models from: #{dir}"
+      Rails.logger.info "[IMPORT] Loading models from: #{dir}"
       Dir.glob(File.join("#{dir}/**/*.rb")).each do |path|
         model_filename = path[/#{Regexp.escape(dir.to_s)}\/([^\.]+).rb/, 1]
 
@@ -98,12 +102,12 @@ namespace :elasticsearch do
         # Skip if the class doesn't have Elasticsearch integration
         next unless klass.respond_to?(:__elasticsearch__)
 
-        puts "[IMPORT] Processing model: #{klass}..."
+        Rails.logger.info "[IMPORT] Processing model: #{klass}..."
 
         ENV['CLASS'] = klass.to_s
         Rake::Task["elasticsearch:import:model"].invoke
         Rake::Task["elasticsearch:import:model"].reenable
-        puts
+        Rails.logger.info ''
       end
     end
 

--- a/elasticsearch-rails/lib/rails/templates/seeds.rb
+++ b/elasticsearch-rails/lib/rails/templates/seeds.rb
@@ -2,7 +2,7 @@ require 'zlib'
 require 'yaml'
 
 Zlib::GzipReader.open(File.expand_path('../articles.yml.gz', __FILE__)) do |gzip|
-  puts "Reading articles from gzipped YAML..."
+  Rails.logger.info "Reading articles from gzipped YAML..."
   @documents = YAML.load_documents(gzip.read)
 end
 


### PR DESCRIPTION
This PR switches out the use of the `puts` method in several places in favour of the [Rails Logger](http://guides.rubyonrails.org/debugging_rails_applications.html).

I've noticed that when I boot my rails project up, there's tons of logs for elasticsearch. For production, the logs for successes don't need to be printed half of the time. This means that this PR also provides a.. wait for it... *performance improvement*!!! (How much? Well I have no idea, but you can research more here: [Impact of Logs on Performance](http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance).)

This PR may cause failing specs since I went a bit haywire in switching out `puts` with a `Rails.logger.some_log_level`. Will revert those changes when I see them in the CI.