### PR TITLE
[MODEL] Add the :includes option to ActiveRecord adapter

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -10,10 +10,17 @@ module Elasticsearch
                          lambda { |klass| !!defined?(::ActiveRecord::Base) && klass.respond_to?(:ancestors) && klass.ancestors.include?(::ActiveRecord::Base) }
 
         module Records
+          attr_writer :options
+
+          def options
+            @options ||= {}
+          end
+
           # Returns an `ActiveRecord::Relation` instance
           #
           def records
             sql_records = klass.where(klass.primary_key => ids)
+            sql_records = sql_records.includes(self.options[:includes]) if self.options[:includes]
 
             # Re-order records based on the order from Elasticsearch hits
             # by redefining `to_a`, unless the user has called `order()`

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -44,8 +44,8 @@ module Elasticsearch
         #
         # @return [Records]
         #
-        def records
-          @records ||= Records.new(klass, self)
+        def records(options = {})
+          @records ||= Records.new(klass, self, options)
         end
 
         # Returns the "took" time

--- a/elasticsearch-model/lib/elasticsearch/model/response/records.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/records.rb
@@ -12,6 +12,8 @@ module Elasticsearch
 
         delegate :each, :empty?, :size, :slice, :[], :to_a, :to_ary, to: :records
 
+        attr_accessor :options
+
         include Base
 
         # @see Base#initialize
@@ -25,6 +27,7 @@ module Elasticsearch
           metaclass = class << self; self; end
           metaclass.__send__ :include, adapter.records_mixin
 
+          self.options = options
           self
         end
 

--- a/elasticsearch-model/test/unit/adapter_active_record_test.rb
+++ b/elasticsearch-model/test/unit/adapter_active_record_test.rb
@@ -51,6 +51,16 @@ class Elasticsearch::Model::AdapterActiveRecordTest < Test::Unit::TestCase
         instance.load
       end
 
+      should "load the records with its submodels when using :includes" do
+        klass    = mock('class', primary_key: :some_key, where: @records)
+        @records.expects(:includes).with([:submodel]).at_least_once
+
+        instance = DummyClassForActiveRecord.new
+        instance.expects(:klass).returns(klass).at_least_once
+        instance.options[:includes] = [:submodel]
+        instance.records
+      end
+
       should "reorder the records based on hits order" do
         @records.instance_variable_set(:@records, @records)
 


### PR DESCRIPTION
that can be used to eager load submodels just like
you'd do with regular ActiveRecord.

This helps eliminate the N+1 problem when using
elasticsearch-model searches.

Example:

    class Article < ActiveRecord::Base
      belongs_to :author

      # ...

    end

    Article.search(...).records(includes: [:author])

    # Would be similar to using:

    Article.includes(:author).where(...)

There might be implications that I'm not considering for other adapters but it works for me with ActiveRecord and all tests are green.