### PR TITLE
[MODEL] Add "suggest" method to get response suggest

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -71,6 +71,12 @@ module Elasticsearch
         def aggregations
           response['aggregations'] ? Hashie::Mash.new(response['aggregations']) : nil
         end
+
+        # Returns a Hashie::Mash of the suggest
+        #
+        def suggest
+          response['suggest'] ? Hashie::Mash.new(response['suggest']) : nil
+        end
       end
     end
   end

--- a/elasticsearch-model/test/unit/response_test.rb
+++ b/elasticsearch-model/test/unit/response_test.rb
@@ -8,7 +8,8 @@ class Elasticsearch::Model::ResponseTest < Test::Unit::TestCase
     end
 
     RESPONSE = { 'took' => '5', 'timed_out' => false, '_shards' => {'one' => 'OK'}, 'hits' => { 'hits' => [] },
-                 'aggregations' => {'foo' => {'bar' => 10}}}
+                 'aggregations' => {'foo' => {'bar' => 10}},
+                 'suggest' => {'my_suggest' => []}}
 
     setup do
       @search  = Elasticsearch::Model::Searching::SearchRequest.new OriginClass, '*'
@@ -72,6 +73,15 @@ class Elasticsearch::Model::ResponseTest < Test::Unit::TestCase
       assert_respond_to response, :aggregations
       assert_kind_of Hashie::Mash, response.aggregations.foo
       assert_equal 10, response.aggregations.foo.bar
+    end
+
+    should "access the suggest" do
+      @search.expects(:execute!).returns(RESPONSE)
+
+      response = Elasticsearch::Model::Response::Response.new OriginClass, @search
+      assert_respond_to response, :suggest
+      assert_kind_of Hashie::Mash, response.suggest
+      assert_equal [], response.suggest.my_suggest
     end
   end
 end

--- a/elasticsearch-rails/lib/rails/templates/index.html.dsl.erb
+++ b/elasticsearch-rails/lib/rails/templates/index.html.dsl.erb
@@ -47,7 +47,7 @@
   <hr>
 </div>
 
-<% if @articles.size < 1 && (suggestions = @articles.response.response['suggest']) && suggestions.present?  %>
+<% if @articles.size < 1 && @articles.response.suggest.present?  %>
 <div class="col-md-12">
   <p class="alert alert-warning">
     No documents have been found.

--- a/elasticsearch-rails/lib/rails/templates/index.html.erb
+++ b/elasticsearch-rails/lib/rails/templates/index.html.erb
@@ -47,7 +47,7 @@
   <hr>
 </div>
 
-<% if @articles.size < 1 && (suggestions = @articles.response.response['suggest']) && suggestions.present?  %>
+<% if @articles.size < 1 && @articles.response.suggest.present?  %>
 <div class="col-md-12">
   <p class="alert alert-warning">
     No documents have been found.

--- a/elasticsearch-rails/lib/rails/templates/search_controller_test.dsl.rb
+++ b/elasticsearch-rails/lib/rails/templates/search_controller_test.dsl.rb
@@ -58,7 +58,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, q: 'one'
     assert_response :success
 
-    suggestions = assigns(:articles).response.response['suggest']
+    suggestions = assigns(:articles).response.suggest
 
     assert_equal 'one', suggestions['suggest_title'][0]['text']
   end

--- a/elasticsearch-rails/lib/rails/templates/search_controller_test.rb
+++ b/elasticsearch-rails/lib/rails/templates/search_controller_test.rb
@@ -58,7 +58,7 @@ class SearchControllerTest < ActionController::TestCase
     get :index, q: 'one'
     assert_response :success
 
-    suggestions = assigns(:articles).response.response['suggest']
+    suggestions = assigns(:articles).response.suggest
 
     assert_equal 'one', suggestions['suggest_title'][0]['text']
   end


### PR DESCRIPTION
I would like to use suggest of Elasticsearch response.
But `Elasticsearch::Model::Response::Response` class hasn't the method. That's why I added it.

I have already signed the CLA.