### PR TITLE
Delay pagination inclusion to first instantiation of Response

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -34,13 +34,6 @@ require 'elasticsearch/model/response/pagination'
 
 require 'elasticsearch/model/ext/active_record'
 
-case
-when defined?(::Kaminari)
-  Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari
-when defined?(::WillPaginate)
-  Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::WillPaginate
-end
-
 module Elasticsearch
 
   # Elasticsearch integration for Ruby models

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -17,7 +17,20 @@ module Elasticsearch
 
         delegate :each, :empty?, :size, :slice, :[], :to_ary, to: :results
 
+        def self.ensure_pagination_included
+          Thread.current[:response_pagination] ||= begin
+            case
+            when defined?(::Kaminari)
+              include(Pagination::Kaminari)
+            when defined?(::WillPaginate)
+              include(Pagination::WillPaginate)
+            end
+            true
+          end
+        end
+
         def initialize(klass, search, options={})
+          self.class.ensure_pagination_included
           @klass     = klass
           @search    = search
         end


### PR DESCRIPTION
This change aims at serving as a first step for discussing alternative implementations to avoid https://github.com/elastic/elasticsearch-rails/issues/489

The approach is to delay the inclusion of the proper pagination module until the very first time a response object is created.

Before, inclusion of pagination modules was done from the outside of the `Response` class, accessing to the private `include` method in the class. Now, the inclusion is done from within the `Response` and memoized in the current thread.
