### PR TITLE
Instance method `exists?`

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -316,6 +316,25 @@ module Elasticsearch
           end if base.respond_to?(:before_save) && base.instance_methods.include?(:changed_attributes)
         end
 
+        # Verifies model instance presence in the index
+        #
+        # @example Checks for identifier presence in the index
+        #
+        #     @article.__elasticsearch__.exists?
+        #     2015-11-26 12:17:00 +0100: HEAD http://localhost:9200/articles/article/1
+        #
+        # @return [true, false]
+        #
+        def exists?(options = {})
+          client.exists?(
+            {
+              id: id,
+              index: index_name,
+              type: document_type
+            }.merge(options)
+          )
+        end
+
         # Serializes the model instance into JSON (by calling `as_indexed_json`),
         # and saves the document into the Elasticsearch index.
         #

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -266,6 +266,20 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance.index_document(parent: 'A')
       end
 
+      should "have the exists? method" do
+        client = mock('client')
+        instance = ::DummyIndexingModelWithCallbacks.new
+
+        client.expects(:exists?).returns(true)
+
+        instance.expects(:client).returns(client)
+        instance.expects(:index_name).returns('foo')
+        instance.expects(:document_type).returns('bar')
+        instance.expects(:id).returns('1')
+
+        instance.exists?
+      end
+
       should "have the delete_document method" do
         client   = mock('client')
         instance = ::DummyIndexingModelWithCallbacks.new


### PR DESCRIPTION
A convenience method to make it easier to verify whether index contains an object corresponding to instance id.