### PR TITLE
Look for `from` and `size` in search body as well

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -47,6 +47,8 @@ module Elasticsearch
             case
               when search.definition[:size]
                 search.definition[:size]
+              when search.definition[:body].try(:[], :size)
+                search.definition[:body][:size]
               else
                 __default_per_page
             end
@@ -58,6 +60,8 @@ module Elasticsearch
             case
               when search.definition[:from]
                 search.definition[:from]
+              when search.definition[:body].try(:[], :from)
+                search.definition[:body][:from]
               else
                 0
             end


### PR DESCRIPTION
[Documentation says](https://www.elastic.co/guide/en/elasticsearch/reference/2.x/search-request-from-size.html):

> Though from and size can be set as request parameters, they can also be set within the search body.

This, maybe a bit to cautiously, _tries_ to implement it.