### PR TITLE
Fix #dup for Elasticsearch::Model

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -66,6 +66,15 @@ module Elasticsearch
         end
       end
 
+      # @overload dup
+      #
+      # Returns a copy of this object. Resets the __elasticsearch__ proxy so
+      # the duplicate will build its own proxy.
+      def initialize_dup(_)
+        @__elasticsearch__ = nil
+        super
+      end
+
       # Common module for the proxy classes
       #
       module Base

--- a/elasticsearch-model/test/unit/proxy_test.rb
+++ b/elasticsearch-model/test/unit/proxy_test.rb
@@ -69,6 +69,17 @@ class Elasticsearch::Model::SearchTest < Test::Unit::TestCase
       assert_equal 'insta barr', DummyProxyModel.new.__elasticsearch__.bar
     end
 
+    should "reset the proxy target for duplicates" do
+      model = DummyProxyModel.new
+      model_target = model.__elasticsearch__.target
+      duplicate = model.dup
+      duplicate_target = duplicate.__elasticsearch__.target
+
+      assert_not_equal model, duplicate
+      assert_equal model, model_target
+      assert_equal duplicate, duplicate_target
+    end
+
     should "return the proxy class from instance proxy" do
       assert_equal Elasticsearch::Model::Proxy::ClassMethodsProxy, DummyProxyModel.new.__elasticsearch__.class.class
     end


### PR DESCRIPTION
Previously, calling `#dup` for an `Elasticsearch::Model` instance would retain the original `__elasticsearch__` reference. Given the following example:

``` ruby
user = User.create!(name: "Will")
other = user.dup
other.update!(name: "Bill")
```

You'd end up with two references to "Will" in Elasticsearch, and none for "Bill," because the duplicate instance proxied to the original instance's attributes.

With this fix, each duplicate gets its own proxy, so attributes are saved correctly.