### PR TITLE
[MODEL] Remove unnecessary code related to kaminari pagination

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -19,8 +19,8 @@ module Elasticsearch
             Elasticsearch::Model::Response::Results.__send__ :include, ::Kaminari::PageScopeMethods
             Elasticsearch::Model::Response::Records.__send__ :include, ::Kaminari::PageScopeMethods
 
-            Elasticsearch::Model::Response::Results.__send__ :delegate, :limit_value, :offset_value, :total_count, :max_pages, to: :response
-            Elasticsearch::Model::Response::Records.__send__ :delegate, :limit_value, :offset_value, :total_count, :max_pages, to: :response
+            Elasticsearch::Model::Response::Results.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
+            Elasticsearch::Model::Response::Records.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
 
             base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               # Define the `page` Kaminari method

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -16,7 +16,6 @@ module Elasticsearch
 
             # Include the Kaminari paging methods in results and records
             #
-            Elasticsearch::Model::Response::Results.__send__ :include, ::Kaminari::ConfigurationMethods::ClassMethods
             Elasticsearch::Model::Response::Results.__send__ :include, ::Kaminari::PageScopeMethods
             Elasticsearch::Model::Response::Records.__send__ :include, ::Kaminari::PageScopeMethods
 

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination.rb
@@ -19,8 +19,9 @@ module Elasticsearch
             Elasticsearch::Model::Response::Results.__send__ :include, ::Kaminari::PageScopeMethods
             Elasticsearch::Model::Response::Records.__send__ :include, ::Kaminari::PageScopeMethods
 
-            Elasticsearch::Model::Response::Results.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
-            Elasticsearch::Model::Response::Records.__send__ :delegate, :limit_value, :offset_value, :total_count, to: :response
+            methods = [:limit_value, :offset_value, :total_count, :max_pages]
+            Elasticsearch::Model::Response::Results.__send__ :delegate, *methods, to: :response
+            Elasticsearch::Model::Response::Records.__send__ :delegate, *methods, to: :response
 
             base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               # Define the `page` Kaminari method

--- a/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
+++ b/elasticsearch-model/test/unit/response_pagination_kaminari_test.rb
@@ -1,9 +1,7 @@
 require 'test_helper'
 
 class Elasticsearch::Model::ResponsePaginationKaminariTest < Test::Unit::TestCase
-  class ModelClass
-    include ::Kaminari::ConfigurationMethods
-
+  class ModelClass    
     def self.index_name;    'foo'; end
     def self.document_type; 'bar'; end
   end


### PR DESCRIPTION
This PR removes unnecessary code in the pagination module, and ensures that the tests added as part of #452 actually check regressively the need for adding `max_pages` method to `Response::Results` and `Response::Records`.
### Context

In #452, the use of Kaminari's `paginate` helper was fixed by implementing the missing method in both the response results and the response records. 

However, the tests added as part of that PR were not actually checking any wrong behaviour, as proven by https://github.com/miguelff/elasticsearch-rails/commit/86b3590a1650a8a94558f6adcf5541022787534e, which removes the method declaration, while the test suite still  passes.

For those tests to proof a missing `max_pages` method was needed, an explicit inclusion of the `Kaminari::ConfigurationMethods` [needed to be removed](https://github.com/elastic/elasticsearch-rails/commit/9261bbddc5320163cb58b0ea31f946f64240f935#diff-ade00d41c79cf78b1678e1ea50010b7cL5).

Also, while investigating #476 I realised there's no longer needed to include `::Kaminari::Configuration::ClassMethods` in `Response::Results`, so [I removed it from the module](https://github.com/miguelff/elasticsearch-rails/commit/1f738cf3dfbd1c435c2a5257a9b871c8d84e9b75)
