### PR TITLE
Bulk save support for repository

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
@@ -108,6 +108,23 @@ module Elasticsearch
         def __extract_id_from_document(document)
           document.delete(:id) || document.delete('id') || document.delete(:_id) || document.delete('_id')
         end
+
+        # Extract an attribute from the document (assuming Hash or Hash-like object)
+        #
+        # @note Calling this method will *remove* the `attribute` key from the passed object.
+        #
+        # @example
+        #     options = { title: 'Test', id: 'abc123', _parent: 'parent' }
+        #     repository.__extract_attribute_from_document(options, :_parent)
+        #     # => "parent"
+        #     options
+        #     # => { title: 'Test', id: 'abc123' }
+        #
+        # @api private
+        #
+        def __extract_attribute_from_document(document, attribute)
+          document.delete(attribute.to_sym) || document.delete(attribute.to_s)
+        end
       end
 
     end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
@@ -6,19 +6,24 @@ module Elasticsearch
       #
       module Store
 
-        # Store the serialized object in Elasticsearch
+        # Store the serialized object or objects in Elasticsearch
         #
         # @example
         #     repository.save(myobject)
         #     => {"_index"=>"...", "_type"=>"...", "_id"=>"...", "_version"=>1, "created"=>true}
         #
+        # @example
+        #     repository.save([myobject, myobject])
+        #     => {"took"=>1, "errors"=>false, "items"=>[{"index"=>{"_index"=>"...", "_type"=>"...", "_id"=>"...", "status"=>200}}]}
+        #
         # @return {Hash} The response from Elasticsearch
         #
-        def save(document, options={})
-          serialized = serialize(document)
-          id   = __get_id_from_document(serialized)
-          type = document_type || __get_type_from_class(klass || document.class)
-          client.index( { index: index_name, type: type, id: id, body: serialized }.merge(options) )
+        def save(document_or_documents, options={})
+          if document_or_documents.is_a?(Array)
+            __save_many(document_or_documents, options)
+          else
+            __save_one(document_or_documents, options)
+          end
         end
 
         # Update the serialized object in Elasticsearch with partial data or script
@@ -88,8 +93,49 @@ module Elasticsearch
           end
           client.delete( { index: index_name, type: type, id: id }.merge(options) )
         end
-      end
 
+        # Save one document using `client.index` method
+        #
+        # @api private
+        #
+        def __save_one(document, options={})
+          document   = document.dup
+          serialized = serialize(document)
+          id   = __get_id_from_document(serialized)
+          type = document_type || __get_type_from_class(klass || document.class)
+          client.index( { index: index_name, type: type, id: id, body: serialized }.merge(options) )
+        end
+
+        # Save multiple documents using `client.bulk` method
+        #
+        # @api private
+        #
+        def __save_many(documents, options={})
+          body = documents.map do |document|
+            document   = document.dup
+            payload    = {}
+            serialized = serialize(document)
+            id         = __get_id_from_document(serialized)
+            type       = document_type || __get_type_from_class(klass || document.class)
+
+            payload[:_id]    = id
+            payload[:_type]  = type
+            payload[:_index] = index_name
+
+            [:_parent, :_version, :_routing].each do |attribute|
+              if value = __extract_attribute_from_document(serialized, attribute)
+                payload[attribute] = value
+              end
+            end
+
+            payload[:data]  = serialized
+
+            { index: payload.merge(options) }
+          end
+
+          client.bulk body: body
+        end
+      end
     end
   end
 end

--- a/elasticsearch-persistence/test/unit/repository_naming_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_naming_test.rb
@@ -50,7 +50,7 @@ class Elasticsearch::Persistence::RepositoryNamingTest < Test::Unit::TestCase
     end
 
     context "extract an ID from the document" do
-      should "delete the key from theHash" do
+      should "delete the key from the Hash" do
         d1 = { :id   => 1 }
         d2 = { :_id  => 1 }
         d3 = { 'id'  => 1 }
@@ -67,6 +67,19 @@ class Elasticsearch::Persistence::RepositoryNamingTest < Test::Unit::TestCase
 
         assert_equal 1, subject.__extract_id_from_document(d4)
         assert_nil   d1['_id']
+      end
+    end
+
+    context "extract an attribute from the document" do
+      should "delete the key from the hash" do
+        d1 = { :_routing  => 'routing-key' }
+        d2 = { '_routing' => 'routing-key' }
+
+        assert_equal 'routing-key', subject.__extract_attribute_from_document(d1, :_routing)
+        assert_nil   d1[:_routing]
+
+        assert_equal 'routing-key', subject.__extract_attribute_from_document(d2, '_routing')
+        assert_nil   d1['_routing']
       end
     end
 


### PR DESCRIPTION
Hi @karmi,

I tried to implement bulk save support for repository pattern (as mentioned in issue https://github.com/elastic/elasticsearch-rails/issues/199).

I'm afraid we can't provide `repository.save(note1, note2)` signature as mentioned in issue, because of optional `options` hash. AFAIK we can pass `Hash` to the `repository#save` method, so I think we can't distinguish:

``` ruby
note1 = { id: 123, content: '' }
note2 = { id: 123, content: '' }
options = {}

repository.save(note1, note2, options)
```

and

``` ruby
repository.save(note1, options)
```

If we are sure, that document is not Hash, we can use something like `def save(*docs, **options)` but as I wrote before. I'm not sure if we can do something like that if document can be `Hash`.

So for now possible use is:

``` ruby
note1 = { id: 123, content: '' }
note2 = { id: 123, content: '' }

repository.save(note1)
# -> individual save

repository.save([note1, note2])
# -> bulk save
```

My second concern is, that `repository#save` now returns two format of responses based on client method call (`index` vs `bulk`). What do you think?
