### PR TITLE
Set the index name as block for Elasticsearch::Persistence::Repository

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
@@ -20,13 +20,31 @@ module Elasticsearch
 
         # Get or set the index name used when storing and retrieving documents
         #
-        def index_name name=nil
-          @index_name = name || @index_name || begin
+        # @example Set the index name for the `Article` model
+        #
+        #     class Article
+        #       index_name "articles-#{Rails.env}"
+        #     end
+        #
+        # @example Set the index name for the `Article` model and re-evaluate it on each call
+        #
+        #     class Article
+        #       index_name { "articles-#{Time.now.year}" }
+        #     end
+        #
+        def index_name(name = nil, &block)
+          @index_name = name || block || @index_name || begin
             if respond_to?(:host) && host && host.is_a?(Module)
               self.host.to_s.underscore.gsub(/\//, '-')
             else
               self.class.to_s.underscore.gsub(/\//, '-')
             end
+          end
+
+          if @index_name.respond_to?(:call)
+            @index_name.call
+          else
+            @index_name
           end
         end; alias :index :index_name
 

--- a/elasticsearch-persistence/test/unit/repository_naming_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_naming_test.rb
@@ -110,6 +110,11 @@ class Elasticsearch::Persistence::RepositoryNamingTest < Test::Unit::TestCase
         assert_equal 'foobar1', subject.index
       end
 
+      should 'be settable with a block' do
+        subject.index_name { 'block1' }
+        assert_equal 'block1', subject.index
+      end
+
       should "be inferred from the host class" do
         class ::MySpecialRepository; end
         subject.define_singleton_method(:host) { MySpecialRepository }


### PR DESCRIPTION
Set the index name as a block similar with Elasticsearch::Model https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/naming.rb#L21

This way the index name can be re-evaluated at every call.
