### PR TITLE
Indexing settings: don't modify input hash

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -22,6 +22,10 @@ module Elasticsearch
           @settings = settings
         end
 
+        def update(additional_settings={})
+          @settings.update(additional_settings)
+        end
+
         def to_hash
           @settings
         end
@@ -186,11 +190,16 @@ module Elasticsearch
         #
         #     # => { "index" => { "number_of_shards" => 1 } }
         #
-        def settings(settings={}, &block)
-          settings = YAML.load(settings.read) if settings.respond_to?(:read)
-          @settings ||= Settings.new({})
+        def settings(settings_hash_or_io={}, &block)
+          additional_settings =
+            if settings_hash_or_io.respond_to?(:read)
+              YAML.load(settings_hash_or_io.read)
+            else
+              settings_hash_or_io
+            end
 
-          @settings.settings.update(settings) unless settings.empty?
+          @settings ||= Settings.new({})
+          @settings.update(additional_settings)
 
           if block_given?
             self.instance_eval(&block)

--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -188,7 +188,7 @@ module Elasticsearch
         #
         def settings(settings={}, &block)
           settings = YAML.load(settings.read) if settings.respond_to?(:read)
-          @settings ||= Settings.new(settings)
+          @settings ||= Settings.new({})
 
           @settings.settings.update(settings) unless settings.empty?
 

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -41,6 +41,13 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         assert_equal( {foo: 'boo', bar: 'bam'},  @dummy_indexing_model.settings.to_hash)
       end
 
+      should "successfully update the index settings when given a frozen hash" do
+        @dummy_indexing_model.settings({foo: 'boo'}.freeze)
+        @dummy_indexing_model.settings({bar: 'bam'}.freeze)
+
+        assert_equal( {foo: 'boo', bar: 'bam'},  @dummy_indexing_model.settings.to_hash)
+      end
+
       should "update and return the index settings from a yml file" do
         @dummy_indexing_model.settings File.open("test/support/model.yml")
         @dummy_indexing_model.settings bar: 'bam'


### PR DESCRIPTION
Hi,

At the moment, if a client passes a frozen hash to `Elasticsearch::Model::Indexing.settings`, a `RuntimeError` ensues, objecting that the hash has been modified. This is because the first call to .settings [initializes a `Settings` instance using the provided hash](https://github.com/Futurelearn/elasticsearch-rails/blob/489ab24998a87a0323c3085e29aad14367bfaf89/elasticsearch-model/lib/elasticsearch/model/indexing.rb#L191), then immediately [merges the same hash with itself](https://github.com/Futurelearn/elasticsearch-rails/blob/489ab24998a87a0323c3085e29aad14367bfaf89/elasticsearch-model/lib/elasticsearch/model/indexing.rb#L193).

This patch addresses the issue by initializing the Settings instance with a new, empty hash, and applying all updates to this.

As part of this PR I've made two further changes. When writing the test for my patch I noticed that there was some order-dependent behaviour in the `Indexing` tests, which meant that I would have needed to assert the presence of settings that weren't applied in my test. I've addressed this in https://github.com/elastic/elasticsearch-rails/commit/350b7eaef8268013f787c632495c2ab6dfa8e416 by using anonymous classes instead of the shared dummy classes the tests previously used.

I've also slightly refactored the `.settings` method, primarily for readability. I've kept this as a separate commit, though, so I'm happy to remove this change if you'd prefer.

Cheers,
Simon

---

Edit: I've signed the CLA, but I'm not sure what to do about the failing build, which appears unrelated to my changes. The tests pass locally, and I'm not able to reproduce the failure.
