### PR TITLE
fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 script:
   - SERVER=launch TEST_CLUSTER_COMMAND=/usr/share/elasticsearch/bin/elasticsearch TEST_CLUSTER_PARAMS='-Des.default.path.conf=/etc/elasticsearch/ -Des.default.path.logs==/var/log/elasticsearch/' bundle exec rake test:all
 
-install: "gem uninstall bundler -axI && gem install bundler -v 1.6.2"
+install: "gem uninstall bundler -axI && gem install bundler -v 1.11.2"
 
 notifications:
   disable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ install: "gem uninstall bundler -axI && gem install bundler -v 1.11.2"
 
 notifications:
   disable: true
+
+sudo: false


### PR DESCRIPTION
* Fix bundler
 * Latest builds on travis are broken because of bundler is too old and contains some issues (Refs: bundler/bundler#3558 travis-ci/travis-ci#3531) .
* Fix buffer overflow
 * Buffer overflow in Java_java_net_Inet4AddressImpl_getLocalHostName of OpenJDK6 and OpenJDK 7 (Refs: https://github.com/travis-ci/travis-ci/issues/5227) .
 * Travis container-based infrastructure does not suffer from the long hostnames.