### PR TITLE
Documentation for Model shuold include Model and not Repository

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -19,7 +19,7 @@ module Elasticsearch
     #     require 'elasticsearch/persistence/model'
     #
     #     class MyObject
-    #       include Elasticsearch::Persistence::Repository
+    #       include Elasticsearch::Persistence::Model
     #     end
     #
     module Model


### PR DESCRIPTION
## Problem

The documentation is pointing that the `Model` module should be included as `include Elasticsearch::Persistence::Repository` and not `include Elasticsearch::Persistence::Model`.
## Solution

Update the docs.
