### PR TITLE
Make find_in_batches work with rails 3

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/find.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/find.rb
@@ -111,7 +111,7 @@ module Elasticsearch
               :_source_include,
               :_source_exclude,
               :stats,
-              :timeout)
+              :timeout).delete_if {|_, value| value.nil? }
 
             scroll = search_params.delete(:scroll) || '5m'
 


### PR DESCRIPTION
`extract!` returns a hash with nil for the values of the extracted keys in rails 3, this does bad things when you try to merge back in the values.
