### PR TITLE
[MODEL] Fix a bug when importing a scope with the same name as the ancestor's method

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -96,7 +96,7 @@ module Elasticsearch
             preprocess = options.delete(:preprocess)
 
             scope = self
-            scope = scope.__send__(named_scope) if named_scope
+            scope = scope.public_send(named_scope) if named_scope
             scope = scope.instance_exec(&query) if query
 
             scope.find_in_batches(options) do |batch|


### PR DESCRIPTION
When I tried to import data from AR with a scope which named 'open', such as this

```ruby
class Issue
  scope :open, -> { where(open: true) }
end

Issue.__elasticsearch__.import(scope: "open")
```

The `__send__` inside `__find_in_batches` will call the `open` from open-uri (ruby 2.2.1p85) and then raises an error.

So I think we should use `public_send` instead of `__send__` to avoid this error.