### PR TITLE
Proxy object destroys inheritance feature

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/naming.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/naming.rb
@@ -77,7 +77,7 @@ module Elasticsearch
 
             if Elasticsearch::Model.settings[:inheritance_enabled]
               self.ancestors.each do |klass|
-                next if klass == self
+                next if klass == self || self.respond_to?(:target) && klass == self.target
                 break if value = klass.respond_to?(prop) && klass.send(prop)
               end
             end


### PR DESCRIPTION
The tests worked great when the objects just had `Elasticsearch::Model::Naming` methods included, but that's not how Elasticsearch is used in real life. In real life, the index_name and document_name are accessed through a proxy, and the tree search was not considering that. This adds tests to confirm the infinite loop that this caused, and then fixes it by checking against the proxy object's target.
