### PR TITLE
[MODEL] Add support for doc_as_upsert option in update action

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -393,13 +393,7 @@ module Elasticsearch
             else
               changed_attributes
             end
-
-            client.update(
-              { index: index_name,
-                type:  document_type,
-                id:    self.id,
-                body:  { doc: attributes } }.merge(options)
-            )
+            update_document_attributes(attributes, options)
           else
             index_document(options)
           end
@@ -420,11 +414,14 @@ module Elasticsearch
         # @return [Hash] The response from Elasticsearch
         #
         def update_document_attributes(attributes, options={})
+          body_params = {}
+          body_params[:doc_as_upsert] = options.delete(:doc_as_upsert) if options[:doc_as_upsert]
+
           client.update(
             { index: index_name,
               type:  document_type,
               id:    self.id,
-              body:  { doc: attributes } }.merge(options)
+              body:  { doc: attributes }.merge(body_params) }.merge(options)
           )
         end
       end

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -400,6 +400,30 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance.update_document_attributes title: "green"
       end
 
+      should "upsert only the specific attributes" do
+        client   = mock('client')
+        instance = ::DummyIndexingModelWithCallbacks.new
+
+        # Set the fake `changes` hash
+        instance.instance_variable_set(:@__changed_attributes, {author: 'john'})
+
+        client.expects(:update).with do |payload|
+          assert_equal 'foo',  payload[:index]
+          assert_equal 'bar',  payload[:type]
+          assert_equal '1',    payload[:id]
+          assert_equal({title: 'green'}, payload[:body][:doc])
+          assert_equal true,   payload[:body][:doc_as_upsert]
+          true
+        end
+
+        instance.expects(:client).returns(client)
+        instance.expects(:index_name).returns('foo')
+        instance.expects(:document_type).returns('bar')
+        instance.expects(:id).returns('1')
+
+        instance.update_document_attributes(title: "green", doc_as_upsert: true)
+      end
+
       should "pass options to the update_document_attributes method" do
         client   = mock('client')
         instance = ::DummyIndexingModelWithCallbacks.new


### PR DESCRIPTION
In some complicated situations, we need UPSERT document in rails model. For example, in one document, data come from two rails models. But one rails model doesn't know if the document has indexed by another rails model in ES, the UPSERT works!
