### PR TITLE
[PERSISTENCE] Fix for #514, #526: Allow before_update callback to access new values…

### DIFF
--- a/elasticsearch-persistence/test/unit/model_store_test.rb
+++ b/elasticsearch-persistence/test/unit/model_store_test.rb
@@ -381,6 +381,46 @@ class Elasticsearch::Persistence::ModelStoreTest < Test::Unit::TestCase
         d.update name: 'Update'
       end
 
+      should "allow the before callbacks to alter any of the updated attributes" do
+        DummyStoreModelWithCallback = Class.new(DummyStoreModel)
+        DummyStoreModelWithCallback.before_update { attr = new_attributes; attr[:title] << ' AGAIN' }
+        d = DummyStoreModelWithCallback.new name: 'Test'
+        d.expects(:persisted?).returns(true)
+        d.expects(:id).returns('abc123').at_least_once
+
+        @gateway
+            .expects(:update)
+            .with do |id, options|
+          assert_equal 'abc123', id
+          assert_equal 'UPDATED AGAIN', options[:doc][:title]
+          true
+        end
+            .returns({'_id' => 'abc123', 'version' => 2})
+
+        assert d.update title: 'UPDATED'
+        assert_equal 'UPDATED AGAIN', d.title
+      end
+
+      should "allow the before callbacks to add attributes to the list of updated attributes" do
+        DummyStoreModelWithCallback = Class.new(DummyStoreModel)
+        DummyStoreModelWithCallback.before_update { attr = new_attributes; attr[:count] = 999 }
+        d = DummyStoreModelWithCallback.new name: 'Test'
+        d.expects(:persisted?).returns(true)
+        d.expects(:id).returns('abc123').at_least_once
+
+        @gateway
+            .expects(:update)
+            .with do |id, options|
+          assert_equal 'abc123', id
+          assert_equal 999, options[:doc][:count]
+          true
+        end
+            .returns({'_id' => 'abc123', 'version' => 2})
+
+        assert d.update title: 'UPDATED'
+        assert_equal 999, d.count
+      end
+
       should "update the model in its own index" do
         @gateway.expects(:update)
           .with do |model, options|


### PR DESCRIPTION
… of attributes and alter them
