### PR TITLE
Use correct method in repository count example.

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
@@ -68,7 +68,7 @@ module Elasticsearch
         #
         # @example Return the count of domain object matching a query in the Elasticsearch DSL
         #
-        #    repository.search(query: { match: { title: 'fox dog' } })
+        #    repository.count(query: { match: { title: 'fox dog' } })
         #    # => 1
         #
         # @return [Integer]


### PR DESCRIPTION
The Repository 'count' example was using 'search' as the method name
instead of 'count'.
