### PR TITLE
[RAILS] Fixed 03-expert.rb set tracer only in dev env

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/03-expert.rb
+++ b/elasticsearch-rails/lib/rails/templates/03-expert.rb
@@ -276,9 +276,8 @@ Elasticsearch::Model.client = Elasticsearch::Client.new host: ELASTICSEARCH_URL
 if Rails.env.development?
   tracer = ActiveSupport::Logger.new('log/elasticsearch.log')
   tracer.level =  Logger::DEBUG
+  Elasticsearch::Model.client.transport.tracer = tracer
 end
-
-Elasticsearch::Model.client.transport.tracer = tracer
 CODE
 
 git add:    "config/initializers"


### PR DESCRIPTION
The variable `tracer` is only defined in Rails development env, so we only can set them in that env.
