### PR TITLE
[MODEL] Scope #records to current collection scope

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/searching.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/searching.rb
@@ -99,7 +99,7 @@ module Elasticsearch
         def search(query_or_payload, options={})
           search   = SearchRequest.new(self, query_or_payload, options)
 
-          Response::Response.new(self, search)
+          Response::Response.new(all, search)
         end
 
       end

--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -217,6 +217,14 @@ module Elasticsearch
           end
         end
 
+        should "return records within the scope the search was called on" do
+          scope = Article.where("clicks >= ?", 2)
+          response = scope.search 'title:test'
+
+          assert_equal 1, response.records.size
+          assert_equal 'Testing Coding', response.records.first.title
+        end
+
         should "allow dot access to response" do
           response = Article.search query: { match: { title: { query: 'test' } } },
                                     aggregations: {

--- a/elasticsearch-model/test/unit/searching_test.rb
+++ b/elasticsearch-model/test/unit/searching_test.rb
@@ -7,6 +7,7 @@ class Elasticsearch::Model::SearchingTest < Test::Unit::TestCase
 
       def self.index_name;    'foo'; end
       def self.document_type; 'bar'; end
+      def self.all;           self;  end
     end
 
     setup do


### PR DESCRIPTION
When calling `#search` on a scoped collection, `#records` would ignore
that scope and query the full model collection. This change maintains
the scope `#search` is called on when calling `#records`. It does not
filter the elasticsearch query, so `#results` is unaffected.
