### PR TITLE
Rails 5 bundle install error

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -145,7 +145,8 @@ say_status  "Application", "Disabling asset logging in development...\n", :yello
 puts        '-'*80, ''; sleep 0.25
 
 environment 'config.assets.logger = false', env: 'development'
-gem 'quiet_assets',  group: "development"
+# quiet_assets move in sprockets-rails > 3.1 https://github.com/rails/sprockets-rails/pull/355 
+# gem 'quiet_assets',  group: "development"
 
 git add:    "Gemfile*"
 git add:    "config/"


### PR DESCRIPTION
Fix bundle install in Rails 5
"As of sprockets-rails version 3.1.0, used in current versions of rails, this gem is deprecated." from https://github.com/evrone/quiet_assets
