### PR TITLE
Fix error in Async Indexing example

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -518,7 +518,7 @@ class Indexer
     case operation.to_s
       when /index/
         record = Article.find(record_id)
-        Client.index  index: 'articles', type: 'article', id: record.id, body: record.as_indexed_json
+        Client.index  index: 'articles', type: 'article', id: record.id, body: record.__elasticsearch__.as_indexed_json
       when /delete/
         Client.delete index: 'articles', type: 'article', id: record_id
       else raise ArgumentError, "Unknown operation '#{operation}'"


### PR DESCRIPTION
Reason for Change
=================
* The"Asynchronous Callbacks" section of the `README.md` contains an example Sidekiq job class.
* I kept getting a "undefined method 'as_indexed_json'", even though I had mixed in `Elasticsearch::Model` which was just puzzling.
* This example class contains an error:


```ruby
Client.index blah: 'blah', body: record.as_indexed_json
```

should be

```ruby
Client.index blah: 'blah', body: record.__elasticsearch__.as_indexed_json
```


Changes
=======
* Fix the error in the `README.md` file.