### PR TITLE
Use search_type=query_then_fetch among with size=0 for count

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
@@ -75,7 +75,7 @@ module Elasticsearch
         #
         def count(query_or_definition=nil, options={})
           query_or_definition ||= { query: { match_all: {} } }
-          response = search query_or_definition, options.update(search_type: 'count')
+          response = search query_or_definition, options.update(search_type: 'query_then_fetch', size: 0)
           response.response.hits.total
         end
       end


### PR DESCRIPTION
According to this:
https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html#_literal_search_type_count_literal_removed

search_type=count is deprecated since 2.0.0 and does not work in 5.0.0