### PR TITLE
Validate updates

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model/store.rb
@@ -112,6 +112,7 @@ module Elasticsearch
           # @return [Hash] The Elasticsearch response as a Hash
           #
           def update(attributes={}, options={})
+            attributes = self.attributes.merge(attributes)
             unless options.delete(:validate) == false
               return false unless valid?
             end


### PR DESCRIPTION
As pointed out in https://github.com/elastic/elasticsearch-rails/issues/450 and https://github.com/elastic/elasticsearch-rails/pull/289, the validation doesn't work when you make an update that makes a field invalid.

My knowledge in elasticsearch is very limited, so I am not sure if updating in [line 115](https://github.com/elastic/elasticsearch-rails/compare/master...dgmora:validate-updates?expand=1#diff-afd98d0d6bf4059de9d5b4ef2a0996a4R115) works well with the attributes being passed directly in [line 126](https://github.com/elastic/elasticsearch-rails/compare/master...dgmora:validate-updates?expand=1#diff-afd98d0d6bf4059de9d5b4ef2a0996a4R126). You **might** want to pass `self.attributes` to update instead.