### PR TITLE
Kaminari::Hooks init call is no longer needed

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -300,10 +300,9 @@ In a Rails controller, use the the `params[:page]` parameter to paginate through
 @articles.next_page
 # => 3
 ```
-To initialize and include the Kaminari pagination support manually:
+To include the Kaminari pagination support manually:
 
 ```ruby
-Kaminari::Hooks.init
 Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari
 ```
 


### PR DESCRIPTION
See: https://github.com/kaminari/kaminari/commit/653143bbd885062a6bc2f3818616e2bbef88444c

For people Googling:

```
/Users/odin/Dev/twe4ked/remember/config/initializers/elasticsearch.rb:1:in `<top (required)>': uninitialized constant Kaminari::Hooks (NameError)
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/engine.rb:648:in `block in load_config_initializer'
        from /Users/odin/.gem/ruby/2.3.1/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/engine.rb:647:in `load_config_initializer'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/engine.rb:612:in `block (2 levels) in <class:Engine>'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/engine.rb:611:in `each'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/engine.rb:611:in `block in <class:Engine>'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/initializable.rb:30:in `instance_exec'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/initializable.rb:30:in `run'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /Users/odin/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
        from /Users/odin/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /Users/odin/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
        from /Users/odin/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /Users/odin/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/initializable.rb:44:in `each'
        from /Users/odin/.gem/ruby/2.3.1/gems/railties-5.0.1/lib/rails/initializable.rb:44:in `tsort_each_child'

# ... snip
```