### PR TITLE
use delete_document and pass on options

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/indexer.rb
+++ b/elasticsearch-rails/lib/rails/templates/indexer.rb
@@ -14,12 +14,10 @@ class Indexer
   def perform(operation, klass, record_id, options = {})
     logger.debug [operation, "#{klass}##{record_id} #{options.inspect}"]
 
-    case operation.to_s
-      when /index|update|delete/
-        record = klass.constantize.find(record_id)
-        record.__elasticsearch__.client = Client
-        record.__elasticsearch__.__send__ "#{operation}_document", options
-      else raise ArgumentError, "Unknown operation '#{operation}'"
-    end
+    raise ArgumentError, "Unknown operation '#{operation}'" unless %w(index update delete).include?(operation.to_s)
+
+    record = klass.constantize.find(record_id)
+    record.__elasticsearch__.client = Client
+    record.__elasticsearch__.__send__ "#{operation}_document", options
   end
 end

--- a/elasticsearch-rails/lib/rails/templates/indexer.rb
+++ b/elasticsearch-rails/lib/rails/templates/indexer.rb
@@ -11,16 +11,14 @@ class Indexer
   Logger = Sidekiq.logger.level == Logger::DEBUG ? Sidekiq.logger : nil
   Client = Elasticsearch::Client.new host: (ENV['ELASTICSEARCH_URL'] || 'http://localhost:9200'), logger: Logger
 
-  def perform(operation, klass, record_id, options={})
+  def perform(operation, klass, record_id, options = {})
     logger.debug [operation, "#{klass}##{record_id} #{options.inspect}"]
 
     case operation.to_s
-      when /index|update/
+      when /index|update|delete/
         record = klass.constantize.find(record_id)
         record.__elasticsearch__.client = Client
-        record.__elasticsearch__.__send__ "#{operation}_document"
-      when /delete/
-        Client.delete index: klass.constantize.index_name, type: klass.constantize.document_type, id: record_id
+        record.__elasticsearch__.__send__ "#{operation}_document", options
       else raise ArgumentError, "Unknown operation '#{operation}'"
     end
   end

--- a/elasticsearch-rails/lib/rails/templates/indexer.rb
+++ b/elasticsearch-rails/lib/rails/templates/indexer.rb
@@ -18,6 +18,6 @@ class Indexer
 
     record = klass.constantize.find(record_id)
     record.__elasticsearch__.client = Client
-    record.__elasticsearch__.__send__ "#{operation}_document", options
+    record.__elasticsearch__.__send__ "#{operation}_document", options.symbolize_keys
   end
 end


### PR DESCRIPTION
The perform method accepts an options hash, but this hash wasn't passed on to the API method.
Also, it was unclear to me why not to use the more high level delete_document method instead of the delete method of the client, so I've updated that as well.

I think the switch case/when can also be replaced with a simple if; 
```rb
%w(index update delete).include?(operation.to_s)
```