### PR TITLE
reindex on assoc updates only if already saved

### DIFF
--- a/elasticsearch-model/examples/activerecord_associations.rb
+++ b/elasticsearch-model/examples/activerecord_associations.rb
@@ -119,8 +119,8 @@ end
 class Article < ActiveRecord::Base
   include Searchable
 
-  has_and_belongs_to_many :categories, after_add:    [ lambda { |a,c| a.__elasticsearch__.index_document if a.id } ],
-                                       after_remove: [ lambda { |a,c| a.__elasticsearch__.index_document if a.id } ]
+  has_and_belongs_to_many :categories, after_add:    [ lambda { |a,c| a.__elasticsearch__.index_document if a.persisted? } ],
+                                       after_remove: [ lambda { |a,c| a.__elasticsearch__.index_document if a.persisted? } ]
   has_many                :authorships
   has_many                :authors, through: :authorships
   has_many                :comments

--- a/elasticsearch-model/examples/activerecord_associations.rb
+++ b/elasticsearch-model/examples/activerecord_associations.rb
@@ -119,8 +119,8 @@ end
 class Article < ActiveRecord::Base
   include Searchable
 
-  has_and_belongs_to_many :categories, after_add:    [ lambda { |a,c| a.__elasticsearch__.index_document } ],
-                                       after_remove: [ lambda { |a,c| a.__elasticsearch__.index_document } ]
+  has_and_belongs_to_many :categories, after_add:    [ lambda { |a,c| a.__elasticsearch__.index_document if a.id } ],
+                                       after_remove: [ lambda { |a,c| a.__elasticsearch__.index_document if a.id } ]
   has_many                :authorships
   has_many                :authors, through: :authorships
   has_many                :comments


### PR DESCRIPTION
Only trigger a re-index if the Article has already been saved. This is important is you ever create an object with `.new` instead of `.create` and then add associations to it _before_ saving (note that rails is smart and will "wait" to do all the database work on `.save` in this case).