### PR TITLE
[MODEL] Fix import method to pass index name on refresh

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -130,7 +130,7 @@ module Elasticsearch
             errors +=  response['items'].select { |k, v| k.values.first['error'] }
           end
 
-          self.refresh_index! if refresh
+          self.refresh_index! index: target_index if refresh
 
           case return_value
             when 'errors'

--- a/elasticsearch-model/test/unit/importing_test.rb
+++ b/elasticsearch-model/test/unit/importing_test.rb
@@ -146,6 +146,27 @@ class Elasticsearch::Model::ImportingTest < Test::Unit::TestCase
       end
     end
 
+    context "with the refresh option" do
+      should "refresh the index" do
+        DummyImportingModel.expects(:__find_in_batches).with do |options|
+          assert_equal 'bar', options[:foo]
+          assert_nil   options[:refresh]
+          true
+        end
+
+        DummyImportingModel.expects(:refresh_index!).with do |options|
+          assert_equal 'foo', options[:index]
+          true
+        end
+
+        DummyImportingModel.expects(:index_name).returns('foo')
+        DummyImportingModel.expects(:document_type).returns('foo')
+        DummyImportingModel.stubs(:index_exists?).returns(true)
+
+        DummyImportingModel.import refresh: true, foo: 'bar'
+      end
+    end
+
     should "allow passing a different index / type" do
       Elasticsearch::Model::Adapter.expects(:from_class)
                                    .with(DummyImportingModel)


### PR DESCRIPTION
Fixes #506

When specifying the index option and refresh option on import, the imported index is not refreshed because the specified index name is not used for refreshing.
