### PR TITLE
Fix basic template when elasticsearch exists

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -22,6 +22,7 @@
 
 require 'uri'
 require 'net/http'
+require 'json'
 
 at_exit do
   pid = File.read("#{destination_root}/tmp/pids/elasticsearch.pid") rescue nil


### PR DESCRIPTION
When attempting to generate a Rails application using the `01-basic.rb`
template the following error occurs when Elasticsearch is already
running.

```
apply  https://raw.github.com/elasticsearch/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb
https://raw.github.com/elasticsearch/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb:39:in `apply': uninitialized constant Rails::Generators::AppGenerator::JSON (NameError)
```

Adding `require 'json'` to the template file fixes this issue.