### PR TITLE
Fix dependence on elasticsearch-ruby to 2.x

### DIFF
--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "elasticsearch",       '~> 1.1'
+  s.add_dependency "elasticsearch",       '~> 2.0'
   s.add_dependency "activesupport",       '> 3'
   s.add_dependency "hashie"
 

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "elasticsearch",       '~> 1.1'
+  s.add_dependency "elasticsearch",       '~> 2.0'
   s.add_dependency "elasticsearch-model", '>= 0.1'
   s.add_dependency "activesupport",       '> 4'
   s.add_dependency "activemodel",         '> 4'


### PR DESCRIPTION
Hi.
According to the readme of [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby#compatibility), 
I think the dependency on elasticsearch-ruby should be to 2.x on this branch.
If it is OK, I hope to have you merge this.