### PR TITLE
Persist attributes changed by callbacks or the save process

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -314,10 +314,10 @@ module Elasticsearch
           #
           # @see #update_document
           #
-          base.before_save do |instance|
+          base.after_save do |instance|
             instance.instance_variable_set(:@__changed_attributes,
-                                  Hash[ instance.changes.map { |key, value| [key, value.last] } ])
-          end if base.respond_to?(:before_save) && base.instance_methods.include?(:changed_attributes)
+                                  Hash[ instance.previous_changes.map { |key, value| [key, value.last] } ])
+          end if base.respond_to?(:after_save) && base.instance_methods.include?(:previous_changes)
         end
 
         # Serializes the model instance into JSON (by calling `as_indexed_json`),

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -167,13 +167,13 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         extend  Elasticsearch::Model::Indexing::ClassMethods
         include Elasticsearch::Model::Indexing::InstanceMethods
 
-        def self.before_save(&block)
+        def self.after_save(&block)
           (@callbacks ||= {})[block.hash] = block
         end
 
         def changed_attributes; [:foo]; end
 
-        def changes
+        def previous_changes
           {:foo => ['One', 'Two']}
         end
       end
@@ -182,13 +182,13 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         extend  Elasticsearch::Model::Indexing::ClassMethods
         include Elasticsearch::Model::Indexing::InstanceMethods
 
-        def self.before_save(&block)
+        def self.after_save(&block)
           (@callbacks ||= {})[block.hash] = block
         end
 
         def changed_attributes; [:foo, :bar]; end
 
-        def changes
+        def previous_changes
           {:foo => ['A', 'B'], :bar => ['C', 'D']}
         end
 
@@ -197,12 +197,12 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         end
       end
 
-      should "register before_save callback when included" do
-        ::DummyIndexingModelWithCallbacks.expects(:before_save).returns(true)
+      should "register after_save callback when included" do
+        ::DummyIndexingModelWithCallbacks.expects(:after_save).returns(true)
         ::DummyIndexingModelWithCallbacks.__send__ :include, Elasticsearch::Model::Indexing::InstanceMethods
       end
 
-      should "set the @__changed_attributes variable before save" do
+      should "set the @__changed_attributes variable after save" do
         instance = ::DummyIndexingModelWithCallbacks.new
         instance.expects(:instance_variable_set).with do |name, value|
           assert_equal :@__changed_attributes, name


### PR DESCRIPTION
If there are `before_save` callbacks in a model that uses `Elasticsearch::Indexing`, and those `before_save` callbacks change attributes of the model, the resulting values might not be saved into Elasticsearch, because `update_document` will only pick up attributes that were changed by the time its own `before_save` callback ran.  Similarly, if the model indexes `updated_at`, it will never be saved into Elasticsearch because that value is updated as part of the save process itself.

This PR changes the behavior of `Elasticsearch::Indexing` to set the `@__changed_attributes` hash in an `after_save` callback, using the `previous_changes` method.  This will contain any attributes changed by other callbacks or the save process itself.

(Also, I'm working on having my company sign the CLA and will let you know when that's done.)