### PR TITLE
Failed to rails-new with 01-basic.rb template

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -22,6 +22,7 @@
 
 require 'uri'
 require 'net/http'
+require 'json'
 
 at_exit do
   pid = File.read("#{destination_root}/tmp/pids/elasticsearch.pid") rescue nil


### PR DESCRIPTION
```sh
$ rails new searchapp --skip --skip-bundle --template https://raw.github.com/elastic/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb
      create
      create  README.md
      create  Rakefile
      create  config.ru
      create  .gitignore
      create  Gemfile
      create  app
      create  app/assets/config/manifest.js
      create  app/assets/javascripts/application.js
      create  app/assets/javascripts/cable.js
      create  app/assets/stylesheets/application.css
      create  app/channels/application_cable/channel.rb
      create  app/channels/application_cable/connection.rb
      create  app/controllers/application_controller.rb
      create  app/helpers/application_helper.rb
      create  app/jobs/application_job.rb
      create  app/mailers/application_mailer.rb
      create  app/models/application_record.rb
      create  app/views/layouts/application.html.erb
      create  app/views/layouts/mailer.html.erb
      create  app/views/layouts/mailer.text.erb
      create  app/assets/images/.keep
      create  app/assets/javascripts/channels
      create  app/assets/javascripts/channels/.keep
      create  app/controllers/concerns/.keep
      create  app/models/concerns/.keep
      create  bin
      create  bin/bundle
      create  bin/rails
      create  bin/rake
      create  bin/setup
      create  bin/update
      create  config
      create  config/routes.rb
      create  config/application.rb
      create  config/environment.rb
      create  config/secrets.yml
      create  config/cable.yml
      create  config/puma.rb
      create  config/spring.rb
      create  config/environments
      create  config/environments/development.rb
      create  config/environments/production.rb
      create  config/environments/test.rb
      create  config/initializers
      create  config/initializers/application_controller_renderer.rb
      create  config/initializers/assets.rb
      create  config/initializers/backtrace_silencers.rb
      create  config/initializers/cookies_serializer.rb
      create  config/initializers/cors.rb
      create  config/initializers/filter_parameter_logging.rb
      create  config/initializers/inflections.rb
      create  config/initializers/mime_types.rb
      create  config/initializers/new_framework_defaults.rb
      create  config/initializers/session_store.rb
      create  config/initializers/wrap_parameters.rb
      create  config/locales
      create  config/locales/en.yml
      create  config/boot.rb
      create  config/database.yml
      create  db
      create  db/seeds.rb
      create  lib
      create  lib/tasks
      create  lib/tasks/.keep
      create  lib/assets
      create  lib/assets/.keep
      create  log
      create  log/.keep
      create  public
      create  public/404.html
      create  public/422.html
      create  public/500.html
      create  public/apple-touch-icon-precomposed.png
      create  public/apple-touch-icon.png
      create  public/favicon.ico
      create  public/robots.txt
      create  test/fixtures
      create  test/fixtures/.keep
      create  test/fixtures/files
      create  test/fixtures/files/.keep
      create  test/controllers
      create  test/controllers/.keep
      create  test/mailers
      create  test/mailers/.keep
      create  test/models
      create  test/models/.keep
      create  test/helpers
      create  test/helpers/.keep
      create  test/integration
      create  test/integration/.keep
      create  test/test_helper.rb
      create  tmp
      create  tmp/.keep
      create  tmp/cache
      create  tmp/cache/assets
      create  vendor/assets/javascripts
      create  vendor/assets/javascripts/.keep
      create  vendor/assets/stylesheets
      create  vendor/assets/stylesheets/.keep
      remove  config/initializers/cors.rb
       apply  https://raw.github.com/elastic/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb
https://raw.github.com/elastic/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb:39:in `apply': uninitialized constant #<Class:#<Rails::Generators::AppGenerator:0x007fdfcfacf330>>::JSON (NameError)
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/actions.rb:224:in `instance_eval'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/actions.rb:224:in `apply'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-5.0.2/lib/rails/generators/app_base.rb:158:in `apply_rails_template'
	from (eval):1:in `apply_rails_template'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `block in invoke_all'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `each'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `map'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `invoke_all'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/group.rb:232:in `dispatch'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-5.0.2/lib/rails/commands/application.rb:17:in `<top (required)>'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-5.0.2/lib/rails/cli.rb:14:in `<top (required)>'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/railties-5.0.2/exe/rails:9:in `<top (required)>'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/bin/rails:22:in `load'
	from /Users/ttanimichi/.anyenv/envs/rbenv/versions/2.4.0/bin/rails:22:in `<main>'
```

```sh
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]

$ rails -v
Rails 5.0.2

$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.12.4
BuildVersion:	16E195
```
