### PR TITLE
Error raised with Rails 5.0.0  / Ruby 2.3.3

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -22,6 +22,7 @@
 
 require 'uri'
 require 'net/http'
+require 'json'
 
 at_exit do
   pid = File.read("#{destination_root}/tmp/pids/elasticsearch.pid") rescue nil


### PR DESCRIPTION
The following error is raised
01-basic.rb:39:in `apply': uninitialized constant #<Class:#<Rails::Generators::AppGenerator:0x00000000e3da28>>::JSON (NameError)
without this line.