### PR TITLE
Solution for the "undefined method `to_hash' for class `Elasticsearch::Model::Response::Result'" error

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -46,7 +46,7 @@ module Elasticsearch
 
         # Respond to methods from `@result` or `@result._source`
         #
-        def respond_to?(method_name, include_private = false)
+        def respond_to_missing?(method_name, include_private = false)
           @result.respond_to?(method_name.to_sym) || \
           @result._source && @result._source.respond_to?(method_name.to_sym) || \
           super


### PR DESCRIPTION
This solution is related with the issue #430 

https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding