### PR TITLE
HashWrapper to avoid hash flooding logs

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -27,6 +27,7 @@ require 'elasticsearch/model/proxy'
 
 require 'elasticsearch/model/response'
 require 'elasticsearch/model/response/base'
+require 'elasticsearch/model/response/hash_wrapper'
 require 'elasticsearch/model/response/result'
 require 'elasticsearch/model/response/results'
 require 'elasticsearch/model/response/records'

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -28,7 +28,7 @@ module Elasticsearch
         #
         def response
           @response ||= begin
-            Hashie::Mash.new(search.execute!)
+            HashWrapper.new(search.execute!)
           end
         end
 
@@ -63,7 +63,7 @@ module Elasticsearch
         # Returns the statistics on shards
         #
         def shards
-          Hashie::Mash.new(response['_shards'])
+          HashWrapper.new(response['_shards'])
         end
 
         # Returns a Hashie::Mash of the aggregations

--- a/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
@@ -2,7 +2,7 @@ module Elasticsearch
   module Model
     module Response
 
-      class Aggregations < Hashie::Mash
+      class Aggregations < HashWrapper
         def initialize(attributes={})
           __redefine_enumerable_methods super(attributes)
         end

--- a/elasticsearch-model/lib/elasticsearch/model/response/hash_wrapper.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/hash_wrapper.rb
@@ -1,0 +1,17 @@
+module Elasticsearch
+  module Model
+    module Response
+
+      # Subclass of `Hashie::Mash` to wrap Hash-like structures
+      # (responses from Elasticsearch, search definitions, etc)
+      #
+      # The primary goal of the subclass is to disable the
+      # warning being printed by Hashie for re-defined
+      # methods, such as `sort`.
+      #
+      class HashWrapper < ::Hashie::Mash
+        disable_warnings if respond_to?(:disable_warnings)
+      end
+    end
+  end
+end

--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -14,7 +14,7 @@ module Elasticsearch
         # @param attributes [Hash] A Hash with document properties
         #
         def initialize(attributes={})
-          @result = Hashie::Mash.new(attributes)
+          @result = HashWrapper.new(attributes)
         end
 
         # Return document `_id` as `id`

--- a/elasticsearch-model/lib/elasticsearch/model/response/suggestions.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/suggestions.rb
@@ -2,7 +2,7 @@ module Elasticsearch
   module Model
     module Response
 
-      class Suggestions < Hashie::Mash
+      class Suggestions < HashWrapper
         def terms
           self.to_a.map { |k,v| v.first['options'] }.flatten.map {|v| v['text']}.uniq
         end


### PR DESCRIPTION
Following the same strategy used in master (https://github.com/elastic/elasticsearch-rails/commit/5732fa31fb84c3fe977fa7d52e5a352264860dfa and https://github.com/elastic/elasticsearch-rails/commit/dd26f59b9e4dbe25f6da9f69588ab680a3f6b730) to avoid Hashie:Mash flooding the logs with warnings about `key`.