### PR TITLE
[MODEL] Added the `:includes` option to Adapter::Multiple::Records

### DIFF
--- a/elasticsearch-model/test/unit/adapter_multiple_test.rb
+++ b/elasticsearch-model/test/unit/adapter_multiple_test.rb
@@ -101,6 +101,21 @@ class Elasticsearch::Model::MultipleTest < Test::Unit::TestCase
 
         assert_equal [2, 2, 1, 1, 3], records.map(&:id)
       end
+
+      should "load the records with its submodels when using :includes" do
+        @records = [ stub(id: 1, inspect: '<Model-1>'), stub(id: 2, inspect: '<Model-2>') ]
+
+        ::DummyOne.stubs(:find).returns(@records)
+        @records.expects(:includes).with([:submodel]).returns(@records).at_least_once
+
+        ::Namespace::DummyTwo.stubs(:find).returns(@records)
+        @records.expects(:includes).with([:submodel, :submodel1]).returns(@records).at_least_once
+
+
+        @multimodel.options[:includes] = { :DummyOne => [:submodel],
+                                           :"Namespace::DummyTwo" => [:submodel, :submodel1] }
+        @multimodel.records
+      end
     end
   end
 end


### PR DESCRIPTION
This patch adds the `:includes` option to Multiple adapter
which can be used to eager load submodels just like
you'd do with regular ActiveRecord.

This helps to eliminate the N+1 problem when using
elasticsearch-model searches.

Example:

    class Article < ActiveRecord::Base
      belongs_to :author

      # ...

    end

    class Comment < ActiveRecord::Base
      belongs_to :article
      belongs_to :user

      # ...

    end

    Elasticsearch::Model.search(..., [Article, Comment]).records(includes: {Article: [:author], Comment: [:article, :user]})

    # Would be similar to using:

    Article.includes(:author).where(...)
    Comment.includes(:article, :user).where(...)