### PR TITLE
bug fix of 01-basic.rb error.

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -22,6 +22,7 @@
 
 require 'uri'
 require 'net/http'
+require 'json'
 
 at_exit do
   pid = File.read("#{destination_root}/tmp/pids/elasticsearch.pid") rescue nil


### PR DESCRIPTION
install has failed, due to not defined JSON.
```
$ rails new elasticsearch --skip --skip-bundle --template https://raw.github.com/elasticsearch/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb
```

Error has raised below
```
       apply  https://raw.github.com/elasticsearch/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb
https://raw.github.com/elasticsearch/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb:39:in `apply': uninitialized constant #<Class:#<Rails::Generators::AppGenerator:0x007fd9c20ba038>>::JSON (NameError)
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/actions.rb:225:in `instance_eval'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/actions.rb:225:in `apply'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/lib/rails/generators/app_base.rb:162:in `apply_rails_template'
	from (eval):1:in `apply_rails_template'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `block in invoke_all'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `each'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `map'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `invoke_all'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/group.rb:232:in `dispatch'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/lib/rails/commands/application/application_command.rb:24:in `perform'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/lib/rails/command/base.rb:63:in `perform'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/lib/rails/command.rb:44:in `invoke'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/lib/rails/cli.rb:16:in `<top (required)>'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.3/exe/rails:9:in `<top (required)>'
	from /usr/local/var/rbenv/versions/2.4.1/bin/rails:22:in `load'
	from /usr/local/var/rbenv/versions/2.4.1/bin/rails:22:in `<main>'
```