### PR TITLE
Update changed_attributes to attributes_in_database

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -54,15 +54,15 @@ module Elasticsearch
           end
 
           # Register a callback for storing changed attributes for models which implement
-          # `before_save` and `changed_attributes` methods (when `Elasticsearch::Model` is included)
+          # `before_save` and `attributes_in_database` methods (when `Elasticsearch::Model` is included)
           #
           # @see http://api.rubyonrails.org/classes/ActiveModel/Dirty.html
           #
           before_save do |i|
-            changed_attr = i.__elasticsearch__.instance_variable_get(:@__changed_attributes) || {}
-            i.__elasticsearch__.instance_variable_set(:@__changed_attributes,
-                                                      changed_attr.merge(Hash[ i.changes.map { |key, value| [key, value.last] } ]))
-          end if respond_to?(:before_save) && instance_methods.include?(:changed_attributes)
+            changed_attr = i.__elasticsearch__.instance_variable_get(:@__attributes_in_database) || {}
+            i.__elasticsearch__.instance_variable_set(:@__attributes_in_database,
+                                                      changed_attr.merge(Hash[ i.changes_to_save.map { |key, value| [key, value.last] } ]))
+          end if respond_to?(:before_save) && instance_methods.include?(:attributes_in_database)
         end
       end
 

--- a/elasticsearch-model/test/unit/indexing_test.rb
+++ b/elasticsearch-model/test/unit/indexing_test.rb
@@ -171,7 +171,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
           (@callbacks ||= {})[block.hash] = block
         end
 
-        def changed_attributes; [:foo]; end
+        def attributes_in_database; [:foo]; end
 
         def changes
           {:foo => ['One', 'Two']}
@@ -186,7 +186,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
           (@callbacks ||= {})[block.hash] = block
         end
 
-        def changed_attributes; [:foo, :bar]; end
+        def attributes_in_database; [:foo, :bar]; end
 
         def changes
           {:foo => ['A', 'B'], :bar => ['C', 'D']}
@@ -202,10 +202,10 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         ::DummyIndexingModelWithCallbacks.__send__ :include, Elasticsearch::Model::Indexing::InstanceMethods
       end
 
-      should "set the @__changed_attributes variable before save" do
+      should "set the @__attributes_in_database variable before save" do
         instance = ::DummyIndexingModelWithCallbacks.new
         instance.expects(:instance_variable_set).with do |name, value|
-          assert_equal :@__changed_attributes, name
+          assert_equal :@__attributes_in_database, name
           assert_equal({foo: 'Two'}, value)
           true
         end
@@ -297,7 +297,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance = ::DummyIndexingModelWithCallbacks.new
 
         # Reset the fake `changes`
-        instance.instance_variable_set(:@__changed_attributes, nil)
+        instance.instance_variable_set(:@__attributes_in_database, nil)
 
         instance.expects(:index_document)
         instance.update_document
@@ -308,7 +308,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance = ::DummyIndexingModelWithCallbacks.new
 
         # Set the fake `changes` hash
-        instance.instance_variable_set(:@__changed_attributes, {foo: 'bar'})
+        instance.instance_variable_set(:@__attributes_in_database, {foo: 'bar'})
 
         client.expects(:update).with do |payload|
           assert_equal 'foo',  payload[:index]
@@ -331,7 +331,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance = ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJson.new
 
         # Set the fake `changes` hash
-        instance.instance_variable_set(:@__changed_attributes, {'foo' => 'B', 'bar' => 'D' })
+        instance.instance_variable_set(:@__attributes_in_database, {'foo' => 'B', 'bar' => 'D' })
 
         client.expects(:update).with do |payload|
           assert_equal({:foo => 'B'}, payload[:body][:doc])
@@ -350,7 +350,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         client   = mock('client')
         instance = ::DummyIndexingModelWithCallbacksAndCustomAsIndexedJson.new
 
-        instance.instance_variable_set(:@__changed_attributes, { 'foo' => { 'bar' => 'BAR'} })
+        instance.instance_variable_set(:@__attributes_in_database, { 'foo' => { 'bar' => 'BAR'} })
         # Overload as_indexed_json
         instance.expects(:as_indexed_json).returns({ 'foo' => 'BAR' })
 
@@ -372,7 +372,7 @@ class Elasticsearch::Model::IndexingTest < Test::Unit::TestCase
         instance = ::DummyIndexingModelWithCallbacks.new
 
         # Set the fake `changes` hash
-        instance.instance_variable_set(:@__changed_attributes, {author: 'john'})
+        instance.instance_variable_set(:@__attributes_in_database, {author: 'john'})
 
         client.expects(:update).with do |payload|
           assert_equal 'foo',  payload[:index]

--- a/elasticsearch-model/test/unit/proxy_test.rb
+++ b/elasticsearch-model/test/unit/proxy_test.rb
@@ -23,7 +23,7 @@ class Elasticsearch::Model::SearchTest < Test::Unit::TestCase
         (@callbacks ||= {})[block.hash] = block
       end
 
-      def changed_attributes; [:foo]; end
+      def attributes_in_database; [:foo]; end
 
       def changes
         {:foo => ['One', 'Two']}
@@ -43,10 +43,10 @@ class Elasticsearch::Model::SearchTest < Test::Unit::TestCase
       DummyProxyModelWithCallbacks.__send__ :include, Elasticsearch::Model::Proxy
     end
 
-    should "set the @__changed_attributes variable before save" do
+    should "set the @__attributes_in_database variable before save" do
       instance = ::DummyProxyModelWithCallbacks.new
       instance.__elasticsearch__.expects(:instance_variable_set).with do |name, value|
-        assert_equal :@__changed_attributes, name
+        assert_equal :@__attributes_in_database, name
         assert_equal({foo: 'Two'}, value)
         true
       end


### PR DESCRIPTION
This PR addresses:

https://github.com/elastic/elasticsearch-rails/issues/714

Basically `changed_attributes` has been deprecated in Rails 5.1.  This PR hopefully addresses that.  Please let me know if I missed anything.