### PR TITLE
update download URL and ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,24 +20,24 @@ branches:
 
 matrix:
   include:
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
-    - rvm: 2.3.3
+    - rvm: 2.3.5
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
-    - rvm: 2.3.3
+    - rvm: 2.3.5
       jdk: oraclejdk8
-      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.0.0-alpha1-SNAPSHOT/bin/elasticsearch
+      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.0.0-rc1-SNAPSHOT/bin/elasticsearch
 
 before_install:
   - gem update --system --no-rdoc --no-ri
   - gem --version
   - gem install bundler -v 1.14.3 --no-rdoc --no-ri
   - bundle version
-  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0-alpha1-SNAPSHOT.tar.gz | tar xz -C /tmp
+  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0-rc1-SNAPSHOT.tar.gz | tar xz -C /tmp
 
 install:
   - bundle install


### PR DESCRIPTION
Other builds are failing due to travis pointing to a download snapshot that no longer exists.  Updated that and ruby versions to attempt to fix that.