### PR TITLE
Avoid unnecessarily incurring the cost of HashWrapper results

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
@@ -18,7 +18,7 @@ module Elasticsearch
           #
           def initialize(repository, response, options={})
             @repository = repository
-            @response   = Elasticsearch::Model::HashWrapper.new(response)
+            @response   = response
             @options    = options
           end
 
@@ -33,13 +33,13 @@ module Elasticsearch
           # The number of total hits for a query
           #
           def total
-            response['hits']['total']
+            @response['hits']['total']
           end
 
           # The maximum score for a query
           #
           def max_score
-            response['hits']['max_score']
+            @response['hits']['max_score']
           end
 
           # Yields [object, hit] pairs to the block
@@ -64,7 +64,7 @@ module Elasticsearch
           # @return [Array]
           #
           def results
-            @results ||= response['hits']['hits'].map do |document|
+            @results ||= @response['hits']['hits'].map do |document|
               repository.deserialize(document.to_hash)
             end
           end
@@ -81,7 +81,7 @@ module Elasticsearch
           # @return [Elasticsearch::Model::HashWrapper]
           #
           def response
-            @response
+            @hash_wrapped_response ||= Elasticsearch::Model::HashWrapper.new(@response)
           end
         end
       end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
@@ -33,13 +33,13 @@ module Elasticsearch
           # The number of total hits for a query
           #
           def total
-            @response['hits']['total']
+            raw_response['hits']['total']
           end
 
           # The maximum score for a query
           #
           def max_score
-            @response['hits']['max_score']
+            raw_response['hits']['max_score']
           end
 
           # Yields [object, hit] pairs to the block
@@ -82,6 +82,21 @@ module Elasticsearch
           #
           def response
             @hash_wrapped_response ||= Elasticsearch::Model::HashWrapper.new(@response)
+          end
+
+          # Access the unwrapped raw response returned from Elasticsearch by the client
+          #
+          # @example Access the aggregations in the response
+          #
+          #     results = repository.search query: { match: { title: 'fox dog' } },
+          #                                 aggregations: { titles: { terms: { field: 'title' } } }
+          #     results.raw_response["aggregations"]["titles"]["buckets"].map { |term| "#{term['key']}: #{term['doc_count']}" }
+          #     # => ["brown: 1", "dog: 1", ...]
+          #
+          # @return [Hash]
+          #
+          def raw_response
+            @response
           end
         end
       end

--- a/elasticsearch-persistence/test/unit/repository_response_results_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_response_results_test.rb
@@ -45,6 +45,14 @@ class Elasticsearch::Persistence::RepositoryResponseResultsTest < Test::Unit::Te
       assert_equal 5, subject.response._shards.total
     end
 
+    should "provide access to the raw response" do
+      assert_equal 5, subject.raw_response['_shards']['total']
+    end
+
+    should "return the raw response unwrapped" do
+      assert_equal @response, subject.raw_response
+    end
+
     should "return the total" do
       assert_equal 2, subject.total
     end


### PR DESCRIPTION
The HashWrapper is very expensive to create. It goes unused unless
specifically accessed. Without breaking backwards compatibility,
this change allows the HashWrapped response to be available, but not
computed for every result by default. This significantly improves
the performance of search results in my tests.

This addresses part of the performance concern in #161 while maintaining backwards compatibility. If you only use the deserialized results, you'll never need to create the HashWrapper. Only if you actually use the response object will you get the wrapped results.

In our app, the creation of a Hashie::Mash was responsible for about 300ms of our 770ms response time. This action only ever used the deserialized result (which is sourced by converting to a Mash, and then back to a Hash) and never the response. Patching this to remove the Mash entirely makes a huge difference in performance.

I hope this can silently help others so they don't need to dig into this particular performance issue.