### PR TITLE
[MODEL] Avoid making an update when no attributes are changed

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -397,7 +397,7 @@ module Elasticsearch
         # @see http://rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions:update
         #
         def update_document(options={})
-          if attributes_in_database = self.instance_variable_get(:@__changed_model_attributes)
+          if attributes_in_database = self.instance_variable_get(:@__changed_model_attributes).presence
             attributes = if respond_to?(:as_indexed_json)
               self.as_indexed_json.select { |k,v| attributes_in_database.keys.map(&:to_s).include? k.to_s }
             else


### PR DESCRIPTION
@dim0627 pointed out in #743 that calling `update_attributes({})` on an ActiveRecord model instance triggers the `before_save` callback, even when there are no attributes to update. This results in an unnecessary empty update request to elasticsearch.

Using ActiveSupport's `presence`, it will act the same for both `nil` and `{}`, which are both ways Rails can express that there are no changes to save.

Closes #743