### PR TITLE
Use Elasticsearch 6.1.0 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ matrix:
 
     - rvm: 2.3.3
       jdk: oraclejdk8
-      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.0.0-alpha1-SNAPSHOT/bin/elasticsearch
+      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.1.0/bin/elasticsearch
 
 before_install:
   - gem update --system --no-rdoc --no-ri
   - gem --version
   - gem install bundler -v 1.14.3 --no-rdoc --no-ri
   - bundle version
-  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0-alpha1-SNAPSHOT.tar.gz | tar xz -C /tmp
+  - curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.0.tar.gz | tar xz -C /tmp
 
 install:
   - bundle install


### PR DESCRIPTION
This allows the tests to run again, though a few are failing as mentioned in https://github.com/elastic/elasticsearch-rails/issues/756#issuecomment-344932630.

e.g.

> Rejecting mapping update to [questions_and_answers] as the final mapping would have more than 1 type: [question, answer]