### PR TITLE
Fix README elasticsearch-model

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -528,7 +528,7 @@ class Indexer
   Logger = Sidekiq.logger.level == Logger::DEBUG ? Sidekiq.logger : nil
   Client = Elasticsearch::Client.new host: 'localhost:9200', logger: Logger
 
-  def perform(operation, record_id)
+  def perform_async(operation, record_id)
     logger.debug [operation, "ID: #{record_id}"]
 
     case operation.to_s


### PR DESCRIPTION
I found an inconsistency method name, inside README of elasticsearch-model's Asynchronous Callbacks section.

You wrote Article Model file as below.

 ```ruby
 class Article
   include Elasticsearch::Model
 
   after_save    { Indexer.perform_async(:index,  self.id) }
   after_destroy { Indexer.perform_async(:delete, self.id) }
 end
 ```

But, you wrote example implementation of the Indexer worker class as below.

```ruby
class Indexer
  include Sidekiq::Worker
  sidekiq_options queue: 'elasticsearch', retry: false
  ［...]
  def perform(operation, record_id)
    ［...]
  end
end
```

I think we should fix Indexer worker class's method name from `perform` to `perform_async`.
