### PR TITLE
Extract lograge module dependencies, for merge it with existing settings

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/lograge.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/lograge.rb
@@ -17,21 +17,7 @@ module Elasticsearch
       #
       class Railtie < ::Rails::Railtie
         initializer "elasticsearch.lograge" do |app|
-          require 'elasticsearch/rails/instrumentation/publishers'
-          require 'elasticsearch/rails/instrumentation/log_subscriber'
-          require 'elasticsearch/rails/instrumentation/controller_runtime'
-
-          Elasticsearch::Model::Searching::SearchRequest.class_eval do
-            include Elasticsearch::Rails::Instrumentation::Publishers::SearchRequest
-          end if defined?(Elasticsearch::Model::Searching::SearchRequest)
-
-          Elasticsearch::Persistence::Model::Find::SearchRequest.class_eval do
-            include Elasticsearch::Rails::Instrumentation::Publishers::SearchRequest
-          end if defined?(Elasticsearch::Persistence::Model::Find::SearchRequest)
-
-          ActiveSupport.on_load(:action_controller) do
-            include Elasticsearch::Rails::Instrumentation::ControllerRuntime
-          end
+          require 'elasticsearch-rails/lib/elasticsearch/rails/lograge_modules'
 
           config.lograge.custom_options = lambda do |event|
             { es: event.payload[:elasticsearch_runtime].to_f.round(2) }

--- a/elasticsearch-rails/lib/elasticsearch/rails/lograge_modules.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/lograge_modules.rb
@@ -1,0 +1,15 @@
+require 'elasticsearch/rails/instrumentation/publishers'
+require 'elasticsearch/rails/instrumentation/log_subscriber'
+require 'elasticsearch/rails/instrumentation/controller_runtime'
+
+Elasticsearch::Model::Searching::SearchRequest.class_eval do
+  include Elasticsearch::Rails::Instrumentation::Publishers::SearchRequest
+end if defined?(Elasticsearch::Model::Searching::SearchRequest)
+
+Elasticsearch::Persistence::Model::Find::SearchRequest.class_eval do
+  include Elasticsearch::Rails::Instrumentation::Publishers::SearchRequest
+end if defined?(Elasticsearch::Persistence::Model::Find::SearchRequest)
+
+ActiveSupport.on_load(:action_controller) do
+  include Elasticsearch::Rails::Instrumentation::ControllerRuntime
+end


### PR DESCRIPTION
Currently is not possible merge the elastic lograge options with exiting option modules. With this change the custom options will look like

```ruby
Rails.application.configure do
  config.lograge.enabled = true
  config.lograge.custom_options = lambda do |event|
    require 'elasticsearch-rails/lib/elasticsearch/rails/lograge_modules'
    { :name => "value", 
      :timing => some_float.round(2), 
      :host => event.payload[:host], 
      :es => event.payload[:elasticsearch_runtime].to_f.round(2} }
  end
end
```