### PR TITLE
Added condition for :update after commit & rescue if record NotFound

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -536,7 +536,11 @@ class Indexer
         record = Article.find(record_id)
         Client.index  index: 'articles', type: 'article', id: record.id, body: record.__elasticsearch__.as_indexed_json
       when /delete/
-        Client.delete index: 'articles', type: 'article', id: record_id
+        begin
+          Client.delete index: 'articles', type: 'article', id: record_id
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound
+          logger.debug "Article not found, ID: #{record_id}"
+        end
       else raise ArgumentError, "Unknown operation '#{operation}'"
     end
   end

--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -494,7 +494,11 @@ class Article < ActiveRecord::Base
   end
 
   after_commit on: [:update] do
-    __elasticsearch__.update_document if self.published?
+    if self.published?
+      __elasticsearch__.update_document
+    else
+      __elasticsearch__.delete_document
+    end
   end
 
   after_commit on: [:destroy] do


### PR DESCRIPTION
Hey guys
I just added readme condition for such case:
Instance of article exists, persisted, and published so successfully indexed. Then, if you make it unpublished, according to current example it will not be indexed, because 
```ruby
self.published? == true
```
I've added condition to delete document if it's non-published, and update if published. In case document was published (created),  then deleted (on update hook), and then published again, `__elasticsearch__.update_document` will create a new document.
Second point is exception handling - when gem trying to delete non-existing document, it throws `Elasticsearch::Transport::Transport::Errors::NotFound`. I've just added `rescue` for it.

Thank you.