### PR TITLE
[CI] Use docker to launch Elasticsearch in rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,15 @@ matrix:
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
-    - rvm: 2.3.3
+    - rvm: 2.5.1
       jdk: oraclejdk8
-      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.3.0/bin/elasticsearch
+      env: TEST_SUITE=integration QUIET=y
 
 before_install:
-  - gem update --system --no-rdoc --no-ri
+  - gem update --system -q
+  - gem update bundler -q
   - gem --version
-  - gem install bundler -v 1.14.3 --no-rdoc --no-ri
   - bundle version
-  - curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.0.tar.gz | tar xz -C /tmp
 
 install:
   - bundle install


### PR DESCRIPTION
The purpose of this pull request is to use docker to launch Elasticsearch, instead of downloading and extracting the tarball.

Note: It is expected that the integration tests will fail, as the work in [this pull request](https://github.com/elastic/elasticsearch-rails/pull/802) is necessary for the tests to pass on ES 6.x.
The tests against Rails 3.0 are also expected to fail. A separate pull request will be made to update the matrix.