### PR TITLE
[CI] Update Travis matrix for 5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,28 @@ branches:
 
 matrix:
   include:
-    - rvm: 2.2.6
+  include:
+    - rvm: 2.2
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
-    - rvm: 2.3.3
+    - rvm: 2.3
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
-    - rvm: 2.3.3
+    - rvm: 2.4
+      jdk: oraclejdk8
+      env: TEST_SUITE=unit
+
+    - rvm: 2.5
+      jdk: oraclejdk8
+      env: TEST_SUITE=unit
+
+#    - rvm: jruby-9.1
+#      jdk: oraclejdk8
+#      env: TEST_SUITE=unit
+
+    - rvm: 2.5
       jdk: oraclejdk8
       env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-5.3.0/bin/elasticsearch
 

--- a/elasticsearch-model/Rakefile
+++ b/elasticsearch-model/Rakefile
@@ -38,10 +38,10 @@ namespace :test do
     sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/5.0.gemfile', __FILE__)}' bundle exec rake test:run_unit"
   end
 
-  desc "Run integration tests against ActiveModel 3, 4 and 5"
+  desc "Run integration tests against latest stable ActiveModel (5)"
   task :integration do
-    sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/3.0.gemfile', __FILE__)}' bundle exec rake test:run_integration"
-    sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/4.0.gemfile', __FILE__)}' bundle exec rake test:run_integration"
+    #sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/3.0.gemfile', __FILE__)}' bundle exec rake test:run_integration"
+    #sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/4.0.gemfile', __FILE__)}' bundle exec rake test:run_integration"
     sh "BUNDLE_GEMFILE='#{File.expand_path('../gemfiles/5.0.gemfile', __FILE__)}' bundle exec rake test:run_integration"
   end
 

--- a/elasticsearch-model/test/unit/multimodel_test.rb
+++ b/elasticsearch-model/test/unit/multimodel_test.rb
@@ -4,8 +4,8 @@ class Elasticsearch::Model::MultimodelTest < Test::Unit::TestCase
 
   context "Multimodel class" do
     setup do
-      title  = stub('Foo', index_name: 'foo_index', document_type: 'foo')
-      series = stub('Bar', index_name: 'bar_index', document_type: 'bar')
+      title  = stub('Foo', index_name: 'foo_index', document_type: 'foo', to_ary: nil)
+      series = stub('Bar', index_name: 'bar_index', document_type: 'bar', to_ary: nil)
       @multimodel = Elasticsearch::Model::Multimodel.new(title, series)
     end
 


### PR DESCRIPTION
 => for each in Ruby version: 2.5.x, 2.4.x, 2.3.x, 2.2.x, JRuby-9.2.x
    -> UNIT w/ Rails 3
    -> UNIT w/ Rails 4
    -> UNIT w/ Rails 5
  => Ruby 2.5.x (latest stable version)
    -> INTEGRATION w Rails 5 & ES 5.x.y (latest stable version) 