### PR TITLE
[CI] Update references to MongoDB Ruby driver

### DIFF
--- a/elasticsearch-model/test/integration/mongoid_basic_test.rb
+++ b/elasticsearch-model/test/integration/mongoid_basic_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
+MongoDB.setup!
 
-Mongo.setup!
-
-if Mongo.available?
-  Mongo.connect_to 'mongoid_articles'
+if MongoDB.available?
+  MongoDB.connect_to 'mongoid_articles'
 
   module Elasticsearch
     module Model

--- a/elasticsearch-model/test/integration/multiple_models_test.rb
+++ b/elasticsearch-model/test/integration/multiple_models_test.rb
@@ -6,7 +6,7 @@ ActiveRecord::Base.establish_connection( :adapter => 'sqlite3', :database => ":m
 
 ::ActiveRecord::Base.raise_in_transactional_callbacks = true if ::ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks) && ::ActiveRecord::VERSION::MAJOR.to_s < '5'
 
-Mongo.setup!
+MongoDB.setup!
 
 module Elasticsearch
   module Model
@@ -115,8 +115,8 @@ module Elasticsearch
           assert_equal 0, response.page(3).per(3).results.size
         end
 
-        if Mongo.available?
-          Mongo.connect_to 'mongoid_collections'
+        if MongoDB.available?
+          MongoDB.connect_to 'mongoid_collections'
 
           context "Across mongoid models" do
             setup do

--- a/elasticsearch-model/test/test_helper.rb
+++ b/elasticsearch-model/test/test_helper.rb
@@ -62,14 +62,13 @@ module Elasticsearch
   end
 end
 
-class Mongo
+class MongoDB
   def self.setup!
     begin
       require 'mongoid'
-      session = Moped::Connection.new("localhost", 27017, 0.5)
-      session.connect
+      Mongo::Client.new(["localhost:27017"])
       ENV['MONGODB_AVAILABLE'] = 'yes'
-    rescue LoadError, Moped::Errors::ConnectionFailure => e
+    rescue LoadError, Mongo::Error => e
       $stderr.puts "MongoDB not installed or running: #{e}"
     end
   end
@@ -86,7 +85,7 @@ class Mongo
     logger.level = ::Logger::DEBUG
 
     Mongoid.logger = logger unless ENV['QUIET']
-    Moped.logger   = logger unless ENV['QUIET']
+    Mongo::Logger.logger   = logger unless ENV['QUIET']
 
     Mongoid.connect_to source
   end


### PR DESCRIPTION
* Update the name of helper module in `test_helper.rb` to `MongoDB` to avoid name clash with MongoDB Ruby driver (`Mongo`)
* Update instantiation of MongoDB Ruby driver client