### PR TITLE
[CI] Test against Elasticsearch 7 on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,14 @@ matrix:
 
     - rvm: 2.5
       jdk: oraclejdk8
-      env: TEST_SUITE=integration QUIET=y
+      env: TEST_SUITE=integration QUIET=y SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_CLUSTER_COMMAND=/tmp/elasticsearch-7.0.0-alpha1-SNAPSHOT/bin/elasticsearch
 
 before_install:
   - gem update --system -q
   - gem update bundler -q
   - gem --version
   - bundle version
+  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-7.0.0-alpha1-SNAPSHOT.tar.gz | tar xz -C /tmp
 
 install:
   - bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -59,28 +59,8 @@ namespace :test do
     end
   end
 
-  desc "Run Elasticsearch (Docker)"
-  task :setup_elasticsearch do
-    begin
-      sh <<-COMMAND.gsub(/^\s*/, '').gsub(/\s{1,}/, ' ')
-          docker run -d=true \
-            --env "discovery.type=single-node" \
-            --env "cluster.name=elasticsearch-rails" \
-            --env "http.port=9200" \
-            --env "cluster.routing.allocation.disk.threshold_enabled=false" \
-            --publish 9250:9200 \
-            --rm \
-            docker.elastic.co/elasticsearch/elasticsearch:6.3.0
-      COMMAND
-      require 'elasticsearch/extensions/test/cluster'
-      Elasticsearch::Extensions::Test::Cluster::Cluster.new(version: '6.3.0',
-                                                            number_of_nodes: 1).wait_for_green
-    rescue
-    end
-  end
-
   desc "Run integration tests in all subprojects"
-  task :integration => :setup_elasticsearch do
+  task :integration do
     # 1/ elasticsearch-model
     #
     puts '-'*80

--- a/elasticsearch-model/test/test_helper.rb
+++ b/elasticsearch-model/test/test_helper.rb
@@ -38,8 +38,7 @@ module Elasticsearch
   module Test
     class IntegrationTestCase < ::Test::Unit::TestCase
       extend Elasticsearch::Extensions::Test::StartupShutdown
-
-      startup  { Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running? }
+      startup  { Elasticsearch::Extensions::Test::Cluster.start(nodes: 1, version: '7.0') if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(version: '7.0') }
       shutdown { Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] && started? }
       context "IntegrationTest" do; should "noop on Ruby 1.8" do; end; end if RUBY_1_8
 


### PR DESCRIPTION
Note that a new version of elasticsearch-extensions must be released so that the version (7.0) can be interpreted as valid.

Ref: https://github.com/elastic/elasticsearch-ruby/blob/v0.0.27/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb#L519-L532

has been updated but not yet released to this:
https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb#L520-L535