### PR TITLE
[STORE] Make default doc type '_doc' in preparation for deprecation of mapping types

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
@@ -57,14 +57,14 @@ module Elasticsearch
         # @return [true, false]
         #
         def exists?(id, options={})
-          type     = document_type || (klass ? __get_type_from_class(klass) : ALL)
+          type     = document_type || ALL
           client.exists( { index: index_name, type: type, id: id }.merge(options) )
         end
 
         # @api private
         #
         def __find_one(id, options={})
-          type     = document_type || (klass ? __get_type_from_class(klass) : ALL)
+          type     = document_type || ALL
           document = client.get( { index: index_name, type: type, id: id }.merge(options) )
 
           deserialize(document)
@@ -75,7 +75,7 @@ module Elasticsearch
         # @api private
         #
         def __find_many(ids, options={})
-          type     = document_type || (klass ? __get_type_from_class(klass) : ALL)
+          type     = document_type || ALL
           documents = client.mget( { index: index_name, type: type, body: { ids: ids } }.merge(options) )
 
           documents[DOCS].map { |document| document[FOUND] ? deserialize(document) : nil }

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
@@ -14,8 +14,12 @@ module Elasticsearch
 
         # Get or set the class used to initialize domain objects when deserializing them
         #
-        def klass name=nil
-          @klass = name || @klass
+        def klass(name=nil)
+          if name
+            @klass = name
+          else
+            @klass
+          end
         end
 
         # Set the class used to initialize domain objects when deserializing them

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/naming.rb
@@ -10,6 +10,8 @@ module Elasticsearch
         #
         IDS = [:id, 'id', :_id, '_id'].freeze
 
+        DEFAULT_DOC_TYPE = '_doc'.freeze
+
         # Get or set the class used to initialize domain objects when deserializing them
         #
         def klass name=nil
@@ -43,7 +45,7 @@ module Elasticsearch
         # Get or set the document type used when storing and retrieving documents
         #
         def document_type name=nil
-          @document_type = name || @document_type || (klass ? klass.to_s.underscore : nil)
+          @document_type = name || @document_type || DEFAULT_DOC_TYPE
         end; alias :type :document_type
 
         # Set the document type used when storing and retrieving documents
@@ -51,38 +53,6 @@ module Elasticsearch
         def document_type=(name)
           @document_type = name
         end; alias :type= :document_type=
-
-        # Get the Ruby class from the Elasticsearch `_type`
-        #
-        # @example
-        #     repository.__get_klass_from_type 'note'
-        #     => Note
-        #
-        # @return [Class] The class corresponding to the passed type
-        # @raise [NameError] if the class cannot be found
-        #
-        # @api private
-        #
-        def __get_klass_from_type(type)
-          klass = type.classify
-          klass.constantize
-        rescue NameError => e
-          raise NameError, "Attempted to get class '#{klass}' from the '#{type}' type, but no such class can be found."
-        end
-
-        # Get the Elasticsearch `_type` from the Ruby class
-        #
-        # @example
-        #     repository.__get_type_from_class Note
-        #     => "note"
-        #
-        # @return [String] The type corresponding to the passed class
-        #
-        # @api private
-        #
-        def __get_type_from_class(klass)
-          klass.to_s.underscore
-        end
 
         # Get a document ID from the document (assuming Hash or Hash-like object)
         #

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
@@ -44,7 +44,7 @@ module Elasticsearch
         # @return [Elasticsearch::Persistence::Repository::Response::Results]
         #
         def search(query_or_definition, options={})
-          type = document_type || (klass ? __get_type_from_class(klass) : nil  )
+          type = document_type
 
           case
           when query_or_definition.respond_to?(:to_hash)
@@ -79,7 +79,7 @@ module Elasticsearch
         #
         def count(query_or_definition=nil, options={})
           query_or_definition ||= { query: { match_all: {} } }
-          type = document_type || (klass ? __get_type_from_class(klass) : nil  )
+          type = document_type
 
           case
           when query_or_definition.respond_to?(:to_hash)

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/serialize.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/serialize.rb
@@ -8,6 +8,14 @@ module Elasticsearch
       #
       module Serialize
 
+        # Error message raised when documents are attempted to be deserialized and no klass is defined for
+        #   the Repository.
+        #
+        # @since 6.0.0
+        NO_CLASS_ERROR_MESSAGE = "No class is defined for deserializing documents. " +
+                                   "Please define a 'klass' for the Repository or define a custom " +
+                                   "deserialize method.".freeze
+
         # The key for document fields in an Elasticsearch query response.
         #
         SOURCE = '_source'.freeze
@@ -31,8 +39,8 @@ module Elasticsearch
         # Use the `klass` property, if defined, otherwise try to get the class from the document's `_type`.
         #
         def deserialize(document)
-          _klass = klass || __get_klass_from_type(document[TYPE])
-          _klass.new document[SOURCE]
+          raise NameError.new(NO_CLASS_ERROR_MESSAGE) unless klass
+          klass.new document[SOURCE]
         end
       end
     end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
@@ -17,7 +17,7 @@ module Elasticsearch
         def save(document, options={})
           serialized = serialize(document)
           id   = __get_id_from_document(serialized)
-          type = document_type || __get_type_from_class(klass || document.class)
+          type = document_type
           client.index( { index: index_name, type: type, id: id, body: serialized }.merge(options) )
         end
 
@@ -48,8 +48,7 @@ module Elasticsearch
 
           type = options.delete(:type) || \
                  (defined?(serialized) && serialized && serialized.delete(:type)) || \
-                 document_type || \
-                 __get_type_from_class(klass)
+                 document_type
 
           if defined?(serialized) && serialized
             body = if serialized[:script]
@@ -80,11 +79,11 @@ module Elasticsearch
         def delete(document, options={})
           if document.is_a?(String) || document.is_a?(Integer)
             id   = document
-            type = document_type || __get_type_from_class(klass)
+            type = document_type
           else
             serialized = serialize(document)
             id   = __get_id_from_document(serialized)
-            type = document_type || __get_type_from_class(klass || document.class)
+            type = document_type
           end
           client.delete( { index: index_name, type: type, id: id }.merge(options) )
         end

--- a/elasticsearch-persistence/test/integration/repository/custom_class_test.rb
+++ b/elasticsearch-persistence/test/integration/repository/custom_class_test.rb
@@ -30,6 +30,7 @@ module Elasticsearch
             include Elasticsearch::Persistence::Repository
 
             klass MyNote
+            document_type 'my_note'
 
             settings number_of_shards: 1 do
               mapping do
@@ -45,6 +46,8 @@ module Elasticsearch
           end
 
           @repository = MyNotesRepository.new
+          @repository.klass = MyNotesRepository.klass
+          @repository.document_type = MyNotesRepository.document_type
 
           @repository.client.cluster.health wait_for_status: 'yellow'
         end

--- a/elasticsearch-persistence/test/integration/repository/default_class_test.rb
+++ b/elasticsearch-persistence/test/integration/repository/default_class_test.rb
@@ -19,6 +19,8 @@ module Elasticsearch
       context "The default repository class" do
         setup do
           @repository = Elasticsearch::Persistence::Repository.new
+          @repository.klass = ::Note
+          @repository.document_type = 'note'
           @repository.client.cluster.health wait_for_status: 'yellow'
         end
 
@@ -105,6 +107,7 @@ module Elasticsearch
         end
 
         should "save and find a plain hash" do
+          @repository.klass = Hash
           @repository.save id: 1, title: 'Hash'
           result = @repository.find(1)
           assert_equal 'Hash', result['_source']['title']

--- a/elasticsearch-persistence/test/integration/repository/virtus_model_test.rb
+++ b/elasticsearch-persistence/test/integration/repository/virtus_model_test.rb
@@ -25,6 +25,7 @@ module Elasticsearch
           @repository = Elasticsearch::Persistence::Repository.new do
             index :pages
             klass Page
+            document_type 'page'
 
             def deserialize(document)
               page = klass.new document['_source']

--- a/elasticsearch-persistence/test/unit/repository_naming_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_naming_test.rb
@@ -11,35 +11,6 @@ class Elasticsearch::Persistence::RepositoryNamingTest < Test::Unit::TestCase
       @shoulda_subject = Class.new() { include Elasticsearch::Persistence::Repository::Naming }.new
     end
 
-    context "get Ruby class from the Elasticsearch type" do
-      should "get a simple class" do
-        assert_equal Foobar, subject.__get_klass_from_type('foobar')
-      end
-      should "get a camelcased class" do
-        assert_equal FooBar, subject.__get_klass_from_type('foo_bar')
-      end
-      should "get a namespaced class" do
-        assert_equal Foo::Bar, subject.__get_klass_from_type('foo/bar')
-      end
-      should "re-raise a NameError exception" do
-        assert_raise NameError do
-          subject.__get_klass_from_type('foobarbazbam')
-        end
-      end
-    end
-
-    context "get Elasticsearch type from the Ruby class" do
-      should "encode a simple class" do
-        assert_equal 'foobar', subject.__get_type_from_class(Foobar)
-      end
-      should "encode a camelcased class" do
-        assert_equal 'foo_bar', subject.__get_type_from_class(FooBar)
-      end
-      should "encode a namespaced class" do
-        assert_equal 'foo/bar', subject.__get_type_from_class(Foo::Bar)
-      end
-    end
-
     context "get an ID from the document" do
       should "get an ID from Hash" do
         assert_equal 1, subject.__get_id_from_document(id: 1)
@@ -118,17 +89,17 @@ class Elasticsearch::Persistence::RepositoryNamingTest < Test::Unit::TestCase
     end
 
     context "document_type" do
-      should "be nil when no klass is set" do
-        assert_equal nil, subject.document_type
+      should "be the default doc type when no klass is set" do
+        assert_equal '_doc', subject.document_type
       end
 
-      should "default to klass" do
+      should "does not use the klass" do
         subject.klass Foobar
-        assert_equal 'foobar', subject.document_type
+        assert_equal '_doc', subject.document_type
       end
 
       should "be aliased as `type`" do
-        subject.klass Foobar
+        subject.document_type 'foobar'
         assert_equal 'foobar', subject.type
       end
 

--- a/elasticsearch-persistence/test/unit/repository_serialize_test.rb
+++ b/elasticsearch-persistence/test/unit/repository_serialize_test.rb
@@ -24,33 +24,17 @@ class Elasticsearch::Persistence::RepositorySerializeTest < Test::Unit::TestCase
     context "deserialize" do
       should "get the class name from #klass" do
         subject.expects(:klass)
-               .returns(MyDocument)
+               .returns(MyDocument).twice
 
         MyDocument.expects(:new)
 
         subject.deserialize( {} )
       end
 
-      should "get the class name from Elasticsearch _type" do
-        subject.expects(:klass)
-               .returns(nil)
-
-        subject.expects(:__get_klass_from_type)
-               .returns(MyDocument)
-
-        MyDocument.expects(:new)
-
-        subject.deserialize( {} )
-      end
-
-      should "create the class instance with _source attributes" do
+      should "raise an error when klass isn't set" do
         subject.expects(:klass).returns(nil)
 
-        subject.expects(:__get_klass_from_type).returns(MyDocument)
-
-        MyDocument.expects(:new).with({ 'foo' => 'bar' })
-
-        subject.deserialize( {'_source' => { 'foo' => 'bar' } } )
+        assert_raise(NameError) { subject.deserialize( {} ) }
       end
     end
   end


### PR DESCRIPTION
See [this documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html#_schedule_for_removal_of_mapping_types).

These changes will require users to define a `document_type` and `klass` on repository objects if they want to maintain previous behavior.
The changes create a path for users to upgrade smoothly to ES 6 and to future versions of ES. Ultimately, document_type will be removed in 7.0, as there won't be the ability to define a mapping type.