### PR TITLE
Revert  #378

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
@@ -64,8 +64,18 @@ module Elasticsearch
           #
           def __find_in_batches(options={}, &block)
             options[:batch_size] ||= 1_000
-  
-            all.no_timeout.each_slice(options[:batch_size]) do |items|
+            items = []
+
+            all.no_timeout.each do |item|
+              items << item
+
+              if items.length % options[:batch_size] == 0
+                yield items
+                items = []
+              end
+            end
+
+            unless items.empty?
               yield items
             end
           end

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/mongoid.rb
@@ -64,19 +64,17 @@ module Elasticsearch
           #
           def __find_in_batches(options={}, &block)
             options[:batch_size] ||= 1_000
-            items = []
 
-            all.no_timeout.each do |item|
-              items << item
-
-              if items.length % options[:batch_size] == 0
-                yield items
-                items = []
-              end
-            end
-
-            unless items.empty?
+            xlen = all.count
+            xi = 0
+            xper = options[:batch_size]
+            xfr = 0
+            loop do
+              xfr = xi * xper
+              break if xfr >= xlen
+              items = asc(:_id).skip(xfr).limit(xper)
               yield items
+              xi += 1
             end
           end
 


### PR DESCRIPTION
#378 is harmful.

When mongo collection is large, `all.no_timeout.each_slice` would consume too much memory.

Please revert the commit 8508577ab0fa33934cc678af426f498e56aa7e3d.

ref: https://github.com/elastic/elasticsearch-rails/commit/8508577ab0fa33934cc678af426f498e56aa7e3d?diff=split