### PR TITLE
[STORE] [MODEL] Address performance of HashWrapper in Response objects

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -27,9 +27,7 @@ module Elasticsearch
         # @return [Hash]
         #
         def response
-          @response ||= begin
-            HashWrapper.new(search.execute!)
-          end
+          @response ||= HashWrapper.new(search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch
@@ -63,7 +61,7 @@ module Elasticsearch
         # Returns the statistics on shards
         #
         def shards
-          HashWrapper.new(response['_shards'])
+          response['_shards']
         end
 
         # Returns a Hashie::Mash of the aggregations
@@ -76,6 +74,10 @@ module Elasticsearch
         #
         def suggestions
           Suggestions.new(response['suggest'])
+        end
+
+        def raw_response
+          @raw_response ||= search.execute!
         end
       end
     end

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -10,8 +10,7 @@ module Elasticsearch
       # Implements Enumerable and forwards its methods to the {#results} object.
       #
       class Response
-        attr_reader :klass, :search, :response,
-                    :took, :timed_out, :shards
+        attr_reader :klass, :search
 
         include Enumerable
 
@@ -49,31 +48,31 @@ module Elasticsearch
         # Returns the "took" time
         #
         def took
-          response['took']
+          raw_response['took']
         end
 
         # Returns whether the response timed out
         #
         def timed_out
-          response['timed_out']
+          raw_response['timed_out']
         end
 
         # Returns the statistics on shards
         #
         def shards
-          response['_shards']
+          @shards ||= HashWrapper.new(raw_response['_shards'])
         end
 
         # Returns a Hashie::Mash of the aggregations
         #
         def aggregations
-          Aggregations.new(response['aggregations'])
+          @aggregations ||= Aggregations.new(raw_response['aggregations'])
         end
 
         # Returns a Hashie::Mash of the suggestions
         #
         def suggestions
-          Suggestions.new(response['suggest'])
+          @suggestions ||= Suggestions.new(raw_response['suggest'])
         end
 
         def raw_response

--- a/elasticsearch-model/lib/elasticsearch/model/response/base.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/base.rb
@@ -13,6 +13,7 @@ module Elasticsearch
         def initialize(klass, response, options={})
           @klass     = klass
           @response  = response
+          @raw_response = response
         end
 
         # @abstract Implement this method in specific class

--- a/elasticsearch-model/lib/elasticsearch/model/response/base.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/base.rb
@@ -4,7 +4,7 @@ module Elasticsearch
       # Common funtionality for classes in the {Elasticsearch::Model::Response} module
       #
       module Base
-        attr_reader :klass, :response
+        attr_reader :klass, :response, :raw_response
 
         # @param klass    [Class] The name of the model class
         # @param response [Hash]  The full response returned from Elasticsearch client
@@ -12,8 +12,8 @@ module Elasticsearch
         #
         def initialize(klass, response, options={})
           @klass     = klass
-          @response  = response
           @raw_response = response
+          @response = response
         end
 
         # @abstract Implement this method in specific class

--- a/elasticsearch-model/test/unit/response_results_test.rb
+++ b/elasticsearch-model/test/unit/response_results_test.rb
@@ -27,5 +27,8 @@ class Elasticsearch::Model::ResultsTest < Test::Unit::TestCase
       assert_equal 'bar', @results.first.foo
     end
 
+    should "provide access to the raw response" do
+      assert_equal RESPONSE, @response.raw_response
+    end
   end
 end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
@@ -11,6 +11,7 @@ module Elasticsearch
           include Enumerable
 
           attr_reader :repository
+          attr_reader :raw_response
 
           # The key for accessing the results in an Elasticsearch query response.
           #
@@ -30,8 +31,8 @@ module Elasticsearch
           #
           def initialize(repository, response, options={})
             @repository = repository
-            @response   = Elasticsearch::Model::HashWrapper.new(response)
-            @options    = options
+            @raw_response = response
+            @options = options
           end
 
           def method_missing(method_name, *arguments, &block)
@@ -45,13 +46,13 @@ module Elasticsearch
           # The number of total hits for a query
           #
           def total
-            response[HITS][TOTAL]
+            raw_response[HITS][TOTAL]
           end
 
           # The maximum score for a query
           #
           def max_score
-            response[HITS][MAX_SCORE]
+            raw_response[HITS][MAX_SCORE]
           end
 
           # Yields [object, hit] pairs to the block
@@ -76,7 +77,7 @@ module Elasticsearch
           # @return [Array]
           #
           def results
-            @results ||= response[HITS][HITS].map do |document|
+            @results ||= raw_response[HITS][HITS].map do |document|
               repository.deserialize(document.to_hash)
             end
           end
@@ -93,7 +94,7 @@ module Elasticsearch
           # @return [Elasticsearch::Model::HashWrapper]
           #
           def response
-            @response
+            @response ||= Elasticsearch::Model::HashWrapper.new(raw_response)
           end
         end
       end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/response/results.rb
@@ -58,13 +58,13 @@ module Elasticsearch
           # Yields [object, hit] pairs to the block
           #
           def each_with_hit(&block)
-            results.zip(response[HITS][HITS]).each(&block)
+            results.zip(raw_response[HITS][HITS]).each(&block)
           end
 
           # Yields [object, hit] pairs and returns the result
           #
           def map_with_hit(&block)
-            results.zip(response[HITS][HITS]).map(&block)
+            results.zip(raw_response[HITS][HITS]).map(&block)
           end
 
           # Return the collection of domain objects

--- a/elasticsearch-persistence/spec/repository/response/results_spec.rb
+++ b/elasticsearch-persistence/spec/repository/response/results_spec.rb
@@ -66,6 +66,22 @@ describe Elasticsearch::Persistence::Repository::Response::Results do
     it 'wraps the response in a HashWrapper' do
       expect(results.response._shards.total).to eq(5)
     end
+
+    context 'when the response method is not called' do
+
+      it 'does not create an instance of HashWrapper' do
+        expect(Elasticsearch::Model::HashWrapper).not_to receive(:new)
+        results
+      end
+    end
+
+    context 'when the response method is called' do
+
+      it 'does create an instance of HashWrapper' do
+        expect(Elasticsearch::Model::HashWrapper).to receive(:new)
+        results.response
+      end
+    end
   end
 
   describe '#total' do
@@ -100,6 +116,13 @@ describe Elasticsearch::Persistence::Repository::Response::Results do
 
     it 'returns the result of the block called on a pair of each raw document and the deserialized object' do
       expect(results.map_with_hit { |pair| pair[0] }).to eq(['Object', 'Object'])
+    end
+  end
+
+  describe '#raw_response' do
+
+    it 'returns the raw response from Elasticsearch' do
+      expect(results.raw_response).to eq(response)
     end
   end
 end


### PR DESCRIPTION
This pull request intends to address the performance issues caused by request responses being wrapped in a `HashWrapper`.
The associated issue and pull request are:
- Issue: https://github.com/elastic/elasticsearch-rails/issues/161
- Pull Request https://github.com/elastic/elasticsearch-rails/pull/755

The changes in this pull request, provide a `#raw_response` method on the response, if users want to avoid creating a HashWrapper for the response results. It also only creates the HashWrapper when the response is accessed, not upon instantiation of the `Repository::Response::Results` object.