### PR TITLE
[MODEL] Allow custom lookup fields to be specified when fetching records

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/records.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/records.rb
@@ -34,7 +34,13 @@ module Elasticsearch
         # Returns the hit IDs
         #
         def ids
-          response.response['hits']['hits'].map { |hit| hit['_id'] }
+          response.response['hits']['hits'].map do |hit|
+            if options[:record_lookup_field]
+              hit['_source'][options[:record_lookup_field]]
+            else
+              hit['_id']
+            end
+          end
         end
 
         # Returns the {Results} collection

--- a/elasticsearch-model/test/unit/adapter_active_record_test.rb
+++ b/elasticsearch-model/test/unit/adapter_active_record_test.rb
@@ -21,7 +21,8 @@ class Elasticsearch::Model::AdapterActiveRecordTest < Test::Unit::TestCase
     RESPONSE = { 'hits' => { 'total' => 123, 'max_score' => 456, 'hits' => [] } }
 
     setup do
-      @records = [ stub(id: 1, inspect: '<Model-1>'), stub(id: 2, inspect: '<Model-2>') ]
+      @records = [ stub(id: 1, inspect: '<Model-1>', class: stub('class', primary_key: :id)),
+                   stub(id: 2, inspect: '<Model-2>', class: stub('class', primary_key: :id)) ]
       @records.stubs(:load).returns(true)
       @records.stubs(:exec_queries).returns(true)
     end


### PR DESCRIPTION
This pull request presents a way to use a custom lookup field for linking an ES query result to a record in your relational datastore.
In this example:
```ruby
response = ArticleWithRecordLookup.search(query: { match: { title: 'Test1' } })
response.records(record_lookup_field: 'relational_id', elasticsearch_lookup_field: 'ip_addr')
```
The above will use the values in the `relational_id` field of the elasticsearch results in a query against the `ip_addr` field in the relational datastore.

This PR addresses issue https://github.com/elastic/elasticsearch-rails/issues/774