### PR TITLE
[MODEL] Fix sort order on ActiveRecord >= 5

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -56,7 +56,10 @@ module Elasticsearch
             # Redefine the `to_a` method to the original one
             #
             sql_records.instance_exec do
-              define_singleton_method(:to_a) do
+              ar_records_method_name = :to_a
+              ar_records_method_name = :records if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 5
+
+              define_singleton_method(ar_records_method_name) do
                 if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 4
                   self.load
                 else

--- a/elasticsearch-model/test/integration/active_record_basic_test.rb
+++ b/elasticsearch-model/test/integration/active_record_basic_test.rb
@@ -223,8 +223,10 @@ module Elasticsearch
 
           if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR >= 4
             assert_equal 'Testing Coding', response.records.order(title: :desc).first.title
+            assert_equal 'Testing Coding', response.records.order(title: :desc)[0].title
           else
             assert_equal 'Testing Coding', response.records.order('title DESC').first.title
+            assert_equal 'Testing Coding', response.records.order('title DESC')[0].title
           end
         end
 


### PR DESCRIPTION
This is addressing an issue in #546 

The monkey patching regarding sort order was not removed when calling `order` on ActiveRecord versions >= 5.

The code introduced in https://github.com/elastic/elasticsearch-rails/pull/618 did not change the `order` method, this patch fixes it.

I have added a test that fails without my new code. The problem with testing the order with `.first` is that it applies the sql `LIMIT 1`, which would return a collection of 1 item from the database. But we want to test the order of the collection returned. Therefore, I added a test for the first item of the collection with `[0]` which doesn't limit the results returned from the db.