### PR TITLE
[RAILS] Log the ElasticSearch query as json

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
@@ -28,7 +28,7 @@ module Elasticsearch
 
           payload = event.payload
           name    = "#{payload[:klass]} #{payload[:name]} (#{event.duration.round(1)}ms)"
-          search  = payload[:search].inspect.gsub(/:(\w+)=>/, '\1: ')
+          search  = payload[:search].to_json
 
           debug %Q|  #{color(name, GREEN, true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
         end


### PR DESCRIPTION
Using `#inspect` on the hash will inspect the values in the hash which
aren't printed according to the JSON spec.

This will change the output from:

```
{query: {range: {created_at: {gt: Tue, 13 Mar 2018 00:00:00 EET +02:00, lt: Wed, 05 Sep 2018 00:00:00 EEST +03:00}}}}
```

to:

```
{"query": {"range":{"created_at":{"gt":"2018-03-13T00:00:00+02:00","lt":"2018-09-05T00:00:00+03:00"}}}}
```

Which makes it a whole lot easier to copy and paste into Kibana for
testing/profiling.