### PR TITLE
`respond_to_missing?` to silence Ruby 2.4 warnings

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/result.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/result.rb
@@ -46,7 +46,7 @@ module Elasticsearch
 
         # Respond to methods from `@result` or `@result._source`
         #
-        def respond_to?(method_name, include_private = false)
+        def respond_to_missing?(method_name, include_private = false)
           @result.respond_to?(method_name.to_sym) || \
           @result._source && @result._source.respond_to?(method_name.to_sym) || \
           super

--- a/elasticsearch-model/spec/elasticsearch/model/response/result_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/result_spec.rb
@@ -53,6 +53,14 @@ describe Elasticsearch::Model::Response::Result do
       expect(result._source).to eq('bar' => { 'bam' => 'baz' })
     end
 
+    it 'is recognized by #method' do
+      expect(result.method :bar).to be_a Method
+    end
+
+    it 'respond_to? still works' do
+      expect(result.respond_to? :bar).to be true
+    end
+
     context 'when methods map to keys in subdocuments of the response from Elasticsearch' do
 
       it 'provides access to top level fields via a method' do


### PR DESCRIPTION
I ran into a bunch of warnings when using Elastic results with
Ruby 2.4+ and trailblazer/cells, because `#method_missing?` without
`#respond_to_missing?` makes Forwardable think all of the Result
attributes are private methods.

https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding