### PR TITLE
[RAILS] Fix seeds file to stop using outdated YAML method

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/seeds.rb
+++ b/elasticsearch-rails/lib/rails/templates/seeds.rb
@@ -3,7 +3,8 @@ require 'yaml'
 
 Zlib::GzipReader.open(File.expand_path('../articles.yml.gz', __FILE__)) do |gzip|
   puts "Reading articles from gzipped YAML..."
-  @documents = YAML.load_documents(gzip.read)
+  @documents = YAML.respond_to?(:load_documents) ? YAML.load_documents(gzip.read) : 
+    YAML.load_stream(gzip.read)
 end
 
 # Truncate the default ActiveRecord logger output


### PR DESCRIPTION
The expert template was using the outdated YAML.load_documents, which is no longer present in the newer versions of Ruby.