### PR TITLE
Prevent double calls to search.execute! by using cached raw_response

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -26,7 +26,7 @@ module Elasticsearch
         # @return [Hash]
         #
         def response
-          @response ||= HashWrapper.new(search.execute!)
+          @response ||= HashWrapper.new(raw_response)
         end
 
         # Returns the collection of "hits" from Elasticsearch

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -26,7 +26,7 @@ module Elasticsearch
         # @return [Hash]
         #
         def response
-          @response ||= HashWrapper.new(raw_response)
+          @response ||= HashWrapper.new(search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch
@@ -59,20 +59,20 @@ module Elasticsearch
 
         # Returns the statistics on shards
         #
-        def shards
-          @shards ||= HashWrapper.new(raw_response['_shards'])
+        def shards(raw_shards = raw_response['_shards'])
+          @shards ||= HashWrapper.new(raw_shards)
         end
 
         # Returns a Hashie::Mash of the aggregations
         #
-        def aggregations
-          @aggregations ||= Aggregations.new(raw_response['aggregations'])
+        def aggregations(raw_aggregations = raw_response['aggregations'])
+          @aggregations ||= Aggregations.new(raw_aggregations)
         end
 
         # Returns a Hashie::Mash of the suggestions
         #
-        def suggestions
-          @suggestions ||= Suggestions.new(raw_response['suggest'])
+        def suggestions(raw_suggestions = raw_response['suggest'])
+          @suggestions ||= Suggestions.new(raw_suggestions)
         end
 
         def raw_response

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -25,8 +25,8 @@ module Elasticsearch
         #
         # @return [Hash]
         #
-        def response
-          @response ||= HashWrapper.new(search.execute!)
+        def response(cache = false)
+          @response ||= HashWrapper.new(cache ? raw_results : search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch
@@ -59,20 +59,20 @@ module Elasticsearch
 
         # Returns the statistics on shards
         #
-        def shards(raw_shards = raw_response['_shards'])
-          @shards ||= HashWrapper.new(raw_shards)
+        def shards
+          @shards ||= HashWrapper.new(raw_response['_shards'])
         end
 
         # Returns a Hashie::Mash of the aggregations
         #
-        def aggregations(raw_aggregations = raw_response['aggregations'])
-          @aggregations ||= Aggregations.new(raw_aggregations)
+        def aggregations()
+          @aggregations ||= Aggregations.new(raw_response['aggregations'])
         end
 
         # Returns a Hashie::Mash of the suggestions
         #
-        def suggestions(raw_suggestions = raw_response['suggest'])
-          @suggestions ||= Suggestions.new(raw_suggestions)
+        def suggestions
+          @suggestions ||= Suggestions.new(raw_response['suggest'])
         end
 
         def raw_response


### PR DESCRIPTION
I was noticing a ton of duplicate search logs in my app, and tracked it down to the `response` method running a non-cached `search.execute!`. An example of when this might occur is the following

````ruby
# Setup search with query and aggregations
response = Post.search('foo')
# Actually execute the search and get results
results = response.results 
# Make a second execution because results raw_response is not being cached
aggregations = response.aggregations
````

By replacing the `search.execute!` within the response method, we can either set, or utilize the cached `raw_results` and prevent double searches.