### PR TITLE
Prevent double calls to search.execute! by using optional cached boolean to return raw_response'

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -23,10 +23,13 @@ module Elasticsearch
 
         # Returns the Elasticsearch response
         #
+        # @param cached [Boolean] Optional parameter that returns the cached initial call
+        #                         instead of executing a new search every time
+        #
         # @return [Hash]
         #
-        def response
-          @response ||= HashWrapper.new(search.execute!)
+        def response(cached = false)
+          @response ||= HashWrapper.new(cached ? raw_results : search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch

--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -29,7 +29,7 @@ module Elasticsearch
         # @return [Hash]
         #
         def response(cached = false)
-          @response ||= HashWrapper.new(cached ? raw_results : search.execute!)
+          @response ||= HashWrapper.new(cached ? raw_response : search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch


### PR DESCRIPTION
I was noticing a ton of duplicate search logs in my app, and tracked it down to the `response` method running a non-cached `search.execute!`. An example of when this might occur is the following

````ruby
# Setup search with query and aggregations
response = Post.search('foo')
# Actually execute the search and get results
results = response.results 
# Make a second execution because results raw_response is not being cached
aggregations = response.aggregations
````

By optionally passing in a `true` cached param, the call replaces the `search.execute!` within the `response method` with a cached `raw_results` to prevent prevent double searches. The new application code would look like: 

````ruby
# Setup search with query and aggregations
response = Post.search('foo')
# Actually execute the search and get cached results
results = response.results(true) 
# Don't make a second execution because results raw_response is already being cached from above
aggregations = response.aggregations
````