### PR TITLE
Prevent double calls to search.execute! when also querying shards, aggregations, and suggestions'

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response.rb
@@ -26,7 +26,7 @@ module Elasticsearch
         # @return [Hash]
         #
         def response
-          @response ||= HashWrapper.new(search.execute!)
+          @response ||= HashWrapper.new(@raw_response = search.execute!)
         end
 
         # Returns the collection of "hits" from Elasticsearch


### PR DESCRIPTION
I was noticing a ton of duplicate search logs in my app, and tracked it down to the `Response.response` method running a `search.execute!` in which the `raw_response` is not being saved, causing subsequent calls to query `shards`, `aggregations`, and `suggestions` to perform another `search.execute!`. call An example of when this might occur is the following

````ruby
# Setup search with query and aggregations
response = Post.search('foo')
# Actually execute the search and get results
results = response.results
# Make a second execution because response's `raw_response` is not being cached
aggregations = response.aggregations
````

By simply storing the `search.execute!` return in the `@raw_response` var, we can utilize the cached `raw_response` in the subsequent calls and prevent double searches.

I have submitted 2 pull requests prior to this one that ended up having pitfalls so I closed them. After some more digging in, I think this simple approach works well. It passes all tests on master, doesn't interfere with pagination (like previous attempt 1) and doesn't add any additional configuration or parameters (like previous attempt 2). Please consider a merge.