### PR TITLE
Fix: Install webpacker before running the server

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -338,6 +338,10 @@ puts        '-'*80, ''
 git tag: "basic"
 git log: "--reverse --oneline"
 
+# ----- Install Webpacker -------------------------------------------------------------------------
+
+run 'rails webpacker:install'
+
 # ----- Start the application ---------------------------------------------------------------------
 
 unless ENV['RAILS_NO_SERVER_START']


### PR DESCRIPTION
There is a `not defined in config/webpacker.yml` error when running the command from the readme:
`rails new searchapp --skip --skip-bundle --template https://raw.github.com/vysogot/elasticsearch-rails/master/elasticsearch-rails/lib/rails/templates/01-basic.rb`

Here's the partial output from before the change:

```
run    rails server --port=3001 from "."
=> Booting Puma
=> Rails 6.0.0.beta3 application starting in development 
=> Run `rails server --help` for more startup options
RAILS_ENV=development environment is not defined in config/webpacker.yml, falling back to production environment
Exiting
Traceback (most recent call last):
	68: from bin/rails:4:in `<main>'
	67: from /Users/jgodawa/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0.beta3/lib/active_support/dependencies.rb:297:in `require'
```

The commit generates config/webpacker.yml file before it tries to run the server.