### PR TITLE
[MODEL] Only add the document_type to the request if it's defined

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -368,14 +368,13 @@ module Elasticsearch
         # @see http://rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions:index
         #
         def index_document(options={})
-          document = self.as_indexed_json
+          document = as_indexed_json
+          request = { index: index_name,
+                      id:    id,
+                      body:  document }
+          request.merge!(type: document_type) if document_type
 
-          client.index(
-            { index: index_name,
-              type:  document_type,
-              id:    self.id,
-              body:  document }.merge(options)
-          )
+          client.index(request.merge!(options))
         end
 
         # Deletes the model instance from the index
@@ -392,11 +391,11 @@ module Elasticsearch
         # @see http://rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions:delete
         #
         def delete_document(options={})
-          client.delete(
-            { index: index_name,
-              type:  document_type,
-              id:    self.id }.merge(options)
-          )
+          request = { index: index_name,
+                      id:    self.id }
+          request.merge!(type: document_type) if document_type
+
+          client.delete(request.merge!(options))
         end
 
         # Tries to gather the changed attributes of a model instance
@@ -431,12 +430,14 @@ module Elasticsearch
               attributes_in_database
             end
 
-            client.update(
-              { index: index_name,
-                type:  document_type,
-                id:    self.id,
-                body:  { doc: attributes } }.merge(options)
-            ) unless attributes.empty?
+            unless attributes.empty?
+              request = { index: index_name,
+                          id:    self.id,
+                          body:  { doc: attributes } }
+              request.merge!(type: document_type) if document_type
+
+              client.update(request.merge!(options))
+            end
           else
             index_document(options)
           end
@@ -457,12 +458,12 @@ module Elasticsearch
         # @return [Hash] The response from Elasticsearch
         #
         def update_document_attributes(attributes, options={})
-          client.update(
-            { index: index_name,
-              type:  document_type,
-              id:    self.id,
-              body:  { doc: attributes } }.merge(options)
-          )
+          request = { index: index_name,
+                      id:    self.id,
+                      body:  { doc: attributes } }
+          request.merge!(type: document_type) if document_type
+
+          client.update(request.merge!(options))
         end
       end
 

--- a/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
@@ -418,7 +418,7 @@ describe Elasticsearch::Model::Indexing do
         expect(instance).to receive(:client).and_return(client)
         expect(instance).to receive(:as_indexed_json).and_return('JSON')
         expect(instance).to receive(:index_name).and_return('foo')
-        expect(instance).to receive(:document_type).and_return('bar')
+        expect(instance).to receive(:document_type).twice.and_return('bar')
         expect(instance).to receive(:id).and_return('1')
       end
 
@@ -458,7 +458,7 @@ describe Elasticsearch::Model::Indexing do
       before do
         expect(instance).to receive(:client).and_return(client)
         expect(instance).to receive(:index_name).and_return('foo')
-        expect(instance).to receive(:document_type).and_return('bar')
+        expect(instance).to receive(:document_type).twice.and_return('bar')
         expect(instance).to receive(:id).and_return('1')
       end
 
@@ -602,7 +602,7 @@ describe Elasticsearch::Model::Indexing do
         before do
           expect(instance).to receive(:client).and_return(client)
           expect(instance).to receive(:index_name).and_return('foo')
-          expect(instance).to receive(:document_type).and_return('bar')
+          expect(instance).to receive(:document_type).twice.and_return('bar')
           expect(instance).to receive(:id).and_return('1')
           instance.instance_variable_set(:@__changed_model_attributes, { author: 'john' })
         end


### PR DESCRIPTION
This reduces the changes eventually needed for Elasticsearch v8.0. 