### PR TITLE
Remove unnecessary `self` as a return value of `initialize` method

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/records.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/records.rb
@@ -45,7 +45,6 @@ module Elasticsearch
           metaclass.__send__ :include, adapter.records_mixin
 
           self.options = options
-          self
         end
 
         # Returns the hit IDs

--- a/elasticsearch-persistence/examples/notes/application.rb
+++ b/elasticsearch-persistence/examples/notes/application.rb
@@ -35,7 +35,6 @@ class Note
     __add_date
     __extract_tags
     __truncate_text
-    self
   end
 
   def method_missing(method_name, *arguments, &block)


### PR DESCRIPTION
`initialize` method returned value is not used usually. Because the method is called by `Class.new`.
So the `self` are not necessary.



note
===

If it is called explicitly, the caller can use the returned value. But it is a super rare case.


```ruby
class C
  def initialize
    1
  end
end


c = C.new
p c.__send__ :initialize # => 1
```