### PR TITLE
Test Rails 6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,7 @@ namespace :bundle do
     end
     sh "rm -f #{__current__.join('elasticsearch-model/gemfiles')}/*.lock"
   end
+  sh "rm -f Gemfile.lock"
 end
 
 namespace :test do

--- a/elasticsearch-model/gemfiles/6.0.gemfile
+++ b/elasticsearch-model/gemfiles/6.0.gemfile
@@ -25,10 +25,10 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel',  '6.0.0.rc1'
-gem 'activerecord', '6.0.0.rc1'
+gem 'activemodel',  '6.0.0'
+gem 'activerecord', '6.0.0'
 gem 'sqlite3' unless defined?(JRUBY_VERSION)
-gem 'mongoid', '~> 6'
+#gem 'mongoid', '~> 6'
 
 group :development, :testing do
   gem 'rspec'

--- a/elasticsearch-model/spec/spec_helper.rb
+++ b/elasticsearch-model/spec/spec_helper.rb
@@ -23,7 +23,11 @@ require 'will_paginate/collection'
 require 'elasticsearch/model'
 require 'hashie/version'
 require 'active_model'
-require 'mongoid'
+begin
+  require 'mongoid'
+rescue LoadError
+  $stderr.puts("'mongoid' gem could not be loaded")
+end
 require 'yaml'
 require 'active_record'
 
@@ -151,8 +155,10 @@ def test_mongoid?
         client.database.command(ping: 1) && true
       end
     end and true
-  rescue Timeout::Error, LoadError, Mongo::Error => e
-    client.close
+  rescue LoadError
+    $stderr.puts("'mongoid' gem could not be loaded")
+  rescue Timeout::Error, Mongo::Error => e
+    client.close if client
     $stderr.puts("MongoDB not installed or running: #{e}")
   end
 end

--- a/elasticsearch-model/spec/support/app.rb
+++ b/elasticsearch-model/spec/support/app.rb
@@ -26,9 +26,7 @@ require 'support/app/namespaced_book'
 require 'support/app/article_for_pagination'
 require 'support/app/article_with_dynamic_index_name'
 require 'support/app/episode'
-require 'support/app/image'
 require 'support/app/series'
-require 'support/app/mongoid_article'
 require 'support/app/article'
 require 'support/app/article_no_type'
 require 'support/app/searchable'
@@ -37,3 +35,12 @@ require 'support/app/author'
 require 'support/app/authorship'
 require 'support/app/comment'
 require 'support/app/post'
+
+
+# Mongoid models
+begin
+  require 'support/app/image'
+  require 'support/app/mongoid_article'
+rescue
+  $stderr.puts("'mongoid' gem is not installed, could not load Mongoid models")
+end


### PR DESCRIPTION
Mongoid hasn't been released yet with support for Rails 6 so this PR adds a few `begin-rescue`'s to catch when Mongoid cannot be loaded.

When Mongoid is released with support for Rails 6, the changes in this PR can be removed.