### PR TITLE
Small update README for asynchronous Callbacks

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -533,7 +533,7 @@ class Indexer
   Logger = Sidekiq.logger.level == Logger::DEBUG ? Sidekiq.logger : nil
   Client = Elasticsearch::Client.new host: 'localhost:9200', logger: Logger
 
-  def perform_async(operation, record_id)
+  def perform(operation, record_id)
     logger.debug [operation, "ID: #{record_id}"]
 
     case operation.to_s


### PR DESCRIPTION
Sidekiq requires `perform` method for workers, with `perform_async` it doesn't work.