### PR TITLE
[DOCS] Move `gem install` to a non-Ruby code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ to learn which releases are still actively supported and tested.
 
 Install each library from [Rubygems](https://rubygems.org/gems/elasticsearch):
 
-```ruby
-gem install elasticsearch-model
-gem install elasticsearch-rails
-```
+    gem install elasticsearch-model
+    gem install elasticsearch-rails
 
 To use an unreleased version, add it to your `Gemfile` for [Bundler](http://bundler.io):
 


### PR DESCRIPTION
`gem install ...` is not Ruby, and the other places with `gem install` also use the indented block style.