### PR TITLE
[MODEL] Do not override existing methods

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -112,7 +112,7 @@ module Elasticsearch
         # Delegate common methods to the `__elasticsearch__` ClassMethodsProxy, unless they are defined already
         class << self
           METHODS.each do |method|
-            delegate method, to: :__elasticsearch__ unless self.respond_to?(method)
+            delegate method, to: :__elasticsearch__ unless self.public_instance_methods.include?(method)
           end
         end
       end

--- a/elasticsearch-model/spec/elasticsearch/model/module_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/module_spec.rb
@@ -48,6 +48,7 @@ describe Elasticsearch::Model do
       end
 
       DummyIncludingModel.__send__ :include, Elasticsearch::Model
+      DummyIncludingModelWithSearchMethodDefined.__send__ :include, Elasticsearch::Model
     end
 
     after(:all) do


### PR DESCRIPTION
This PR reverts the line from this commit: https://github.com/elastic/elasticsearch-rails/pull/893/files to address the issue described here https://github.com/elastic/elasticsearch-rails/issues/924

My biggest concern is that this is a very subtle change in behavior that could lead to bugs, especially in a project where custom methods with similar names (import, search, etc.) are defined. It seems safer to keep the existing behavior (pre 7.x.x elasticsearch-rails) and force users who are facing this sort of conflict to be more explicit about their method choice (via `ModelName.__elasticsearch__.method()`)