### PR TITLE
fix: Ruby 2.7 deprecation warning on find_in_batches

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/active_record.rb
@@ -102,7 +102,7 @@ module Elasticsearch
             scope = scope.__send__(named_scope) if named_scope
             scope = scope.instance_exec(&query) if query
 
-            scope.find_in_batches(options) do |batch|
+            scope.find_in_batches(**options) do |batch|
               batch = self.__send__(preprocess, batch) if preprocess
               yield(batch) if batch.present?
             end


### PR DESCRIPTION
Calling Model#import with Ruby 2.7 results in a deprecation warning due to passing options into `find_in_batches` as keyword arguments without explicitly stating so:

```
.../activerecord-6.0.3/lib/active_record/querying.rb:21: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
.../activerecord-6.0.3/lib/active_record/relation/batches.rb:126: warning: The called method `find_in_batches' is defined here
```