### PR TITLE
[#966] Add alias for Elasticsearch::Model::Response::Results#records

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/results.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/results.rb
@@ -42,6 +42,7 @@ module Elasticsearch
           response.response['hits']['hits'].map { |hit| Result.new(hit) }
         end
 
+        alias records results
       end
     end
   end

--- a/elasticsearch-model/spec/elasticsearch/model/response/results_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/results_spec.rb
@@ -48,6 +48,10 @@ describe Elasticsearch::Model::Response::Results do
     response.results
   end
 
+  let(:records) do
+    response.records
+  end
+
   describe '#results' do
 
     it 'provides access to the results' do
@@ -68,6 +72,14 @@ describe Elasticsearch::Model::Response::Results do
 
     it 'returns the raw response document' do
       expect(response.raw_response).to eq(response_document)
+    end
+  end
+
+  describe '#records' do
+
+    it 'provides access to the records' do
+      expect(results.records.size).to be(results.results.size)
+      expect(results.records.first.foo).to eq(results.results.first.foo)
     end
   end
 end


### PR DESCRIPTION
Quick Fix for #966 