### PR TITLE
deal with `nil` document types in Multimodel

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -85,7 +85,7 @@ module Elasticsearch
       # @return [Array] the list of document types used for retrieving documents
       #
       def document_type
-        models.map { |m| m.document_type }
+        models.map { |m| m.document_type }.compact.presence
       end
 
       # Get the client common for all models


### PR DESCRIPTION
The simplest solution to deal with the [removal of types](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html) in ElasticSearch is simply to use single-type indices and not set `document_type` on models.

However Multimodel did not deal with that case and ended up calling a URL ending in `my-index//_search` instead of  `my-index/_search`, which caused the types warning:

> warning: 299 Elasticsearch-7.9.1-083627f112ba94dffc1232e8b42b73492789ef91 "[types removal] Specifying types in search requests is deprecated."

This PR fixes that issue.