### PR TITLE
Update dependency to explicitly support version 7

### DIFF
--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '> 3'
-  s.add_dependency 'elasticsearch', '> 1'
+  s.add_dependency 'elasticsearch', '~> 7'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'activemodel', '> 3'


### PR DESCRIPTION
While creating a patch for #980, I have found out the currently supported
`elasticsearch` version by `elasticsearch-model` is unnecessarily wide. ( `> 1` )

Also, the previous dependency of `> 1` and the nonexistence of version-parameterized test
means that the CI is not running against versions under 7.x. for `elasticsearch-model`.

I doubt the current code on `master` still works for old versions,
and I would like to avoid writing code to support compatibility on old versions on master branch.

To solve this issue, I have updated the dependency based on Elasticsearch gems' version policy.
This improves gem consistency and maintenance efficiency.

c.f. 
https://github.com/elastic/elasticsearch-rails/tree/756a4dae1c51331a54bab8f00b0fcb88b4a480ad/elasticsearch-model#compatibility
#875