### PR TITLE
Stop emitting FATAL log when checking existence of indices 

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -270,7 +270,7 @@ module Elasticsearch
         def index_exists?(options={})
           target_index = options[:index] || self.index_name
 
-          self.client.indices.exists(index: target_index) rescue false
+          self.client.indices.exists(index: target_index, ignore: 404)
         end
 
         # Deletes the index with corresponding name

--- a/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
@@ -659,36 +659,6 @@ describe Elasticsearch::Model::Indexing do
         expect(DummyIndexingModel.index_exists?).to be(false)
       end
     end
-
-    context 'when the index API raises an error' do
-
-      let(:client) do
-        double('client').tap do |cl|
-          expect(cl).to receive(:indices).and_raise(StandardError)
-        end
-      end
-
-      it 'returns false' do
-        expect(DummyIndexingModel.index_exists?).to be(false)
-      end
-    end
-
-    context 'when the indices.exists API raises an error' do
-
-      let(:client) do
-        double('client', indices: indices)
-      end
-
-      let(:indices) do
-        double('indices').tap do |ind|
-          expect(ind).to receive(:exists).and_raise(StandardError)
-        end
-      end
-
-      it 'returns false' do
-        expect(DummyIndexingModel.index_exists?).to be(false)
-      end
-    end
   end
 
   describe '#delete_index!' do


### PR DESCRIPTION
This fixes #980.

## Summary

Passing `ignore: 404` to Elasticsearch::Client can stop
FATAL log in addition to stopping exception.

This option is supported since the 5.0.4 and 6.0.0 of `elasticsearch-ruby`.
https://github.com/elastic/elasticsearch-ruby/blob/36d45f0c12f4e9ef96646f269748ad33b43e974c/CHANGELOG.md#600
https://github.com/elastic/elasticsearch-ruby/blob/36d45f0c12f4e9ef96646f269748ad33b43e974c/CHANGELOG.md#504

This swallowing was implemented following exception catching as follows.
elastic/elasticsearch-ruby@9848c97

## Test

Unnecessary tests on exceptions are also removed, and following code
covers the required tests.
https://github.com/aeroastro/elasticsearch-rails/blob/c4daaad152517114aa568e326b0388ab8b883e1d/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb#L652-L661

I have confirmed that the reproduction code on #980 does not emit exceptions nor FATAL log with this patch.

Although the test on not logging `FATAL [404]` is omitted in this Pull Request,
I believe it is not the responsibility of `Elasticsearch::Model`, but that of `Elasticsearch::Client`.

## Version Dependency

This code on master branch does not work well with 
2.x and 0.1 of `elasticsearch` gems, where `ignore: 404` option is not supported.
However, I assume the current maintenance policy does not support old versions
on master branch, and therefore the current code is O.K.

c.f. #981