### PR TITLE
Removes dependency on extensions, updates CI

### DIFF
--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -35,6 +35,9 @@ jobs:
         bundle install
         bundle exec rake bundle:clean
         bundle exec rake bundle:install
-    - name: Test
-      run: bundle exec rake test:all
-        
+    - name: Test elasticsearch-rails
+      run: cd elasticsearch-rails && bundle exec rake test:all
+    - name: Test elasticsearch-persistence
+      run: cd elasticsearch-persistence && bundle exec rake test:all
+    - name: Test elasticsearch-model
+      run: cd elasticsearch-model && bundle exec rake test:all

--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -24,7 +24,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.9.0
+        stack-version: 7.x-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -35,6 +35,10 @@ jobs:
         bundle install
         bundle exec rake bundle:clean
         bundle exec rake bundle:install
-    - name: Test
-      run: bundle exec rake test:all
+    - name: Test elasticsearch-rails
+      run: cd elasticsearch-rails && bundle exec rake test:all
+    - name: Test elasticsearch-persistence
+      run: cd elasticsearch-persistence && bundle exec rake test:all
+    - name: Test elasticsearch-model
+      run: cd elasticsearch-model && bundle exec rake test:all
         

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -24,7 +24,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.9.0
+        stack-version: 7.x-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -24,7 +24,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.9.0
+        stack-version: 7.x-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -35,6 +35,9 @@ jobs:
         bundle install
         bundle exec rake bundle:clean
         bundle exec rake bundle:install
-    - name: Test
-      run: bundle exec rake test:all
-        
+    - name: Test elasticsearch-rails
+      run: cd elasticsearch-rails && bundle exec rake test:all
+    - name: Test elasticsearch-persistence
+      run: cd elasticsearch-persistence && bundle exec rake test:all
+    - name: Test elasticsearch-model
+      run: cd elasticsearch-model && bundle exec rake test:all

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -35,6 +35,9 @@ jobs:
         bundle install
         bundle exec rake bundle:clean
         bundle exec rake bundle:install
-    - name: Test
-      run: bundle exec rake test:all
-        
+    - name: Test elasticsearch-rails
+      run: cd elasticsearch-rails && bundle exec rake test:all
+    - name: Test elasticsearch-persistence
+      run: cd elasticsearch-persistence && bundle exec rake test:all
+    - name: Test elasticsearch-model
+      run: cd elasticsearch-model && bundle exec rake test:all

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -24,7 +24,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.9.0
+        stack-version: 7.x-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -35,6 +35,7 @@ jobs:
         bundle install
         bundle exec rake bundle:clean
         bundle exec rake bundle:install
-    - name: Test
-      run: bundle exec rake test:all
-        
+    - name: Test elasticsearch-rails
+      run: cd elasticsearch-rails && bundle exec rake test:all
+    - name: Test elasticsearch-persistence
+      run: cd elasticsearch-persistence && bundle exec rake test:all

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -24,7 +24,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.9.0
+        stack-version: 7.x-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.2

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,7 @@
 source 'https://rubygems.org'
 
 gem "rake", "~> 12"
-
-gem 'elasticsearch-extensions'
-
+gem "elasticsearch"
 gem "pry"
 gem "ansi"
 gem "cane"

--- a/README.md
+++ b/README.md
@@ -160,11 +160,7 @@ You can also unit, integration, or both tests for all sub-projects from the top-
 
     rake test:all
 
-The test suite expects an Elasticsearch cluster running on port 9250, and **will delete all the data**. You can launch an isolated, in-memory Elasticsearch cluster with the following Rake task:
-
-    TEST_CLUSTER_COMMAND=/tmp/builds/elasticsearch-2.0.0-SNAPSHOT/bin/elasticsearch TEST_CLUSTER_NODES=1 bundle exec rake test:cluster:start
-
-See more information in the documentation  for the [`elasticsearch-extensions`](https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-extensions#testcluster) gem.
+The test suite expects an Elasticsearch cluster running on port 9250, and **will delete all the data**.
 
 ## License
 

--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activemodel', '> 3'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'elasticsearch-extensions'
   s.add_development_dependency 'kaminari'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -53,8 +53,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", '> 4'
 
-  s.add_development_dependency "elasticsearch-extensions"
-
   s.add_development_dependency "minitest"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda-context"

--- a/elasticsearch-rails/elasticsearch-rails.gemspec
+++ b/elasticsearch-rails/elasticsearch-rails.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'elasticsearch-extensions'
   s.add_development_dependency 'lograge'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
This PR addresses some maintenance issues:
- Removes dev dependency on `elasticsearch-extensions`.
- Refactors GitHub Actions and updates the stack to use latest `7.x`.