### PR TITLE
Fixed dependency for Rails template

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/01-basic.rb
+++ b/elasticsearch-rails/lib/rails/templates/01-basic.rb
@@ -156,7 +156,7 @@ puts
 say_status  "Rubygems", "Adding Elasticsearch libraries into Gemfile...\n", :yellow
 puts        '-'*80, ''; sleep 0.75
 
-gem 'elasticsearch',       git: 'https://github.com/elasticsearch/elasticsearch-ruby.git'
+gem 'elasticsearch'
 gem 'elasticsearch-model', git: 'https://github.com/elasticsearch/elasticsearch-rails.git'
 gem 'elasticsearch-rails', git: 'https://github.com/elasticsearch/elasticsearch-rails.git'
 


### PR DESCRIPTION
Related: #984, #983
I also failed to start the rails app from the template due to a dependency problem.
So remove the git repository setting from ``01-basic.rb`` following Gemfile.




