### PR TITLE
Allow chaining scope or includes when searching across multiple models

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -72,7 +72,7 @@ module Elasticsearch
 
             # Allow calling `.records()` with options:
             # ex: `klass.name => [{ method: :includes, args: [:association]}, { method: :scope_name }]`
-            if (klass_options = options&.dig(klass.name))
+            if (klass_options = @options&.dig(klass.name))
               klass_options.each { |opts| klass = klass.public_send(opts[:method], *opts[:args]) }
             end
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -70,6 +70,12 @@ module Elasticsearch
           def __records_for_klass(klass, ids)
             adapter = __adapter_for_klass(klass)
 
+            # Allow calling `.records()` with options:
+            # klass.name => [{ method: :includes, args: [:association]}, { method: :scope_name }]
+            if (klass_options = @options.dig(klass.name))
+              klass_options.each { klass = klass.public_send(_1[:method], *_1[:args]) }
+            end
+
             case
               when Elasticsearch::Model::Adapter::ActiveRecord.equal?(adapter)
                 klass.where(klass.primary_key => ids)

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -71,8 +71,8 @@ module Elasticsearch
             adapter = __adapter_for_klass(klass)
 
             # Allow calling `.records()` with options:
-            # klass.name => [{ method: :includes, args: [:association]}, { method: :scope_name }]
-            if (klass_options = @options.dig(klass.name))
+            # ex: `klass.name => [{ method: :includes, args: [:association]}, { method: :scope_name }]`
+            if (klass_options = options&.dig(klass.name))
               klass_options.each { |opts| klass = klass.public_send(opts[:method], *opts[:args]) }
             end
 

--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -73,7 +73,7 @@ module Elasticsearch
             # Allow calling `.records()` with options:
             # klass.name => [{ method: :includes, args: [:association]}, { method: :scope_name }]
             if (klass_options = @options.dig(klass.name))
-              klass_options.each { klass = klass.public_send(_1[:method], *_1[:args]) }
+              klass_options.each { |opts| klass = klass.public_send(opts[:method], *opts[:args]) }
             end
 
             case


### PR DESCRIPTION
## Why is this PR needed?

Fixes #990

## notes

Must use `klass.name` instead of klass (#912)