### PR TITLE
Add compatibility with Ruby 3

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -117,8 +117,8 @@ module Elasticsearch
 
         # Delegate methods to `@target`
         #
-        def method_missing(method_name, *arguments, &block)
-          target.respond_to?(method_name) ? target.__send__(method_name, *arguments, &block) : super
+        def method_missing(method_name, *args, **kwargs, &block)
+          target.respond_to?(method_name) ? target.__send__(method_name, *args, **kwargs, &block) : super
         end
 
         # Respond to methods from `@target`

--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -115,10 +115,13 @@ module Elasticsearch
           @target = target
         end
 
-        # Delegate methods to `@target`
+        def ruby2_keywords(*) # :nodoc:
+        end if RUBY_VERSION < "2.7"
+
+        # Delegate methods to `@target`. As per [the Ruby 3.0 explanation for keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), the only way to work on Ruby <2.7, and 2.7, and 3.0+ is to use `ruby2_keywords`.
         #
-        def method_missing(method_name, *args, **kwargs, &block)
-          target.respond_to?(method_name) ? target.__send__(method_name, *args, **kwargs, &block) : super
+        ruby2_keywords def method_missing(method_name, *arguments, &block)
+          target.respond_to?(method_name) ? target.__send__(method_name, *arguments, &block) : super
         end
 
         # Respond to methods from `@target`

--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -123,7 +123,7 @@ module Elasticsearch
 
         # Respond to methods from `@target`
         #
-        def respond_to?(method_name, include_private = false)
+        def respond_to_missing?(method_name, include_private = false)
           target.respond_to?(method_name) || super
         end
 

--- a/elasticsearch-model/spec/elasticsearch/model/proxy_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/proxy_spec.rb
@@ -31,6 +31,10 @@ describe Elasticsearch::Model::Proxy do
         'insta barr'
       end
 
+      def keyword_method(foo: 'default value')
+        foo
+      end
+
       def as_json(options)
         {foo: 'bar'}
       end
@@ -98,7 +102,6 @@ describe Elasticsearch::Model::Proxy do
   end
 
   context 'when instances are cloned' do
-
     let!(:model) do
       DummyProxyModel.new
     end
@@ -121,4 +124,9 @@ describe Elasticsearch::Model::Proxy do
       expect(duplicate).to eq(duplicate_target)
     end
   end
+
+  it 'forwards keyword arguments to target methods' do
+    expect(DummyProxyModel.new.__elasticsearch__.keyword_method(foo: 'bar')).to eq('bar')
+  end
+
 end


### PR DESCRIPTION
Since Ruby 3 changed the way keyword arguments work, Rails now only accepts keyword arguments for `find_in_batches`. Unfortunately, the `method_missing` implementation on `Elasticsearch::Model::Proxy` doesn't proxy keyword arguments, so Rails now explodes. The error is triggered by calling `Model.import`, and looks something like this:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
bundle/gems/activerecord-6.1.3.1/lib/active_record/relation/batches.rb:128:in 'find_in_batches'
```

The fix is to forward not just positional arguments, but also keyword arguments. This PR adds a test (failing before the patch), and a patch to forward keyword arguments.

Fixes #989, #977.