### PR TITLE
Updates transport references and alias for Elasticsearch::Model::Response::Results#records

### DIFF
--- a/elasticsearch-model/examples/activerecord_associations.rb
+++ b/elasticsearch-model/examples/activerecord_associations.rb
@@ -81,7 +81,7 @@ end
 # ----- Elasticsearch client setup ----------------------------------------------------------------
 
 Elasticsearch::Model.client = Elasticsearch::Client.new log: true
-Elasticsearch::Model.client.transport.logger.formatter = proc { |s, d, p, m| "\e[2m#{m}\n\e[0m" }
+Elasticsearch::Model.client.transport.transport.logger.formatter = proc { |s, d, p, m| "\e[2m#{m}\n\e[0m" }
 
 # ----- Search integration ------------------------------------------------------------------------
 

--- a/elasticsearch-model/examples/activerecord_custom_analyzer.rb
+++ b/elasticsearch-model/examples/activerecord_custom_analyzer.rb
@@ -37,8 +37,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 end
 
-Elasticsearch::Model.client.transport.logger = ActiveSupport::Logger.new(STDOUT)
-Elasticsearch::Model.client.transport.logger.formatter = lambda { |s, d, p, m| "#{m.ansi(:faint)}\n" }
+Elasticsearch::Model.client.transport.transport.logger = ActiveSupport::Logger.new(STDOUT)
+Elasticsearch::Model.client.transport.transport.logger.formatter = lambda { |s, d, p, m| "#{m.ansi(:faint)}\n" }
 
 class Article < ActiveRecord::Base
   include Elasticsearch::Model

--- a/elasticsearch-model/lib/elasticsearch/model/response/results.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/results.rb
@@ -42,6 +42,7 @@ module Elasticsearch
           response.response['hits']['hits'].map { |hit| Result.new(hit) }
         end
 
+        alias records results
       end
     end
   end

--- a/elasticsearch-model/spec/elasticsearch/model/response/results_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/results_spec.rb
@@ -48,6 +48,10 @@ describe Elasticsearch::Model::Response::Results do
     response.results
   end
 
+  let(:records) do
+    response.records
+  end
+
   describe '#results' do
 
     it 'provides access to the results' do
@@ -68,6 +72,14 @@ describe Elasticsearch::Model::Response::Results do
 
     it 'returns the raw response document' do
       expect(response.raw_response).to eq(response_document)
+    end
+  end
+
+  describe '#records' do
+
+    it 'provides access to the records' do
+      expect(results.records.size).to be(results.results.size)
+      expect(results.records.first.foo).to eq(results.results.first.foo)
     end
   end
 end

--- a/elasticsearch-persistence/README.md
+++ b/elasticsearch-persistence/README.md
@@ -236,7 +236,7 @@ You can also override the default configuration with options passed to the initi
 
 ```ruby
 client = Elasticsearch::Client.new(url: 'http://localhost:9250', log: true)
-client.transport.logger.formatter = proc { |s, d, p, m| "\e[2m# #{m}\n\e[0m" }
+client.transport.transport.logger.formatter = proc { |s, d, p, m| "\e[2m# #{m}\n\e[0m" }
 repository = NoteRepository.new(client: client, index_name: 'notes_development')
 
 repository.create_index!(force: true)
@@ -267,7 +267,7 @@ The repository uses the standard Elasticsearch [client](https://github.com/elast
 ```ruby
 client = Elasticsearch::Client.new(url: 'http://search.server.org')
 repository = NoteRepository.new(client: client)
-repository.client.transport.logger = Logger.new(STDERR)
+repository.client.transport.transport.logger = Logger.new(STDERR)
 repository.client
 # => Elasticsearch::Client
 

--- a/elasticsearch-persistence/examples/notes/test.rb
+++ b/elasticsearch-persistence/examples/notes/test.rb
@@ -90,7 +90,7 @@ class Elasticsearch::Persistence::ExampleApplicationTest < Test::Unit::TestCase
       app.settings.repository.client = Elasticsearch::Client.new \
         hosts: [{ host: 'localhost', port: ENV.fetch('TEST_CLUSTER_PORT', 9250)}],
         log: true
-      app.settings.repository.client.transport.logger.formatter = proc { |s, d, p, m| "\e[2m#{m}\n\e[0m" }
+      app.settings.repository.client.transport.transport.logger.formatter = proc { |s, d, p, m| "\e[2m#{m}\n\e[0m" }
       app.settings.repository.create_index! force: true
       app.settings.repository.client.cluster.health wait_for_status: 'yellow'
     end


### PR DESCRIPTION
Includes commits from #976