### PR TITLE
Fix error while doing bundle error. Branch name is changed from maste…

### DIFF
--- a/elasticsearch-persistence/examples/notes/Gemfile
+++ b/elasticsearch-persistence/examples/notes/Gemfile
@@ -26,8 +26,8 @@ gem 'hashie'
 
 gem 'patron'
 gem 'elasticsearch'
-gem 'elasticsearch-model',       git: 'https://github.com/elastic/elasticsearch-rails.git'
-gem 'elasticsearch-persistence', git: 'https://github.com/elastic/elasticsearch-rails.git'
+gem 'elasticsearch-model',       git: 'https://github.com/elastic/elasticsearch-rails.git', branch: 'main'
+gem 'elasticsearch-persistence', git: 'https://github.com/elastic/elasticsearch-rails.git', branch: 'main'
 
 gem 'sinatra', require: false
 gem 'thin'

--- a/elasticsearch-persistence/examples/notes/application.rb
+++ b/elasticsearch-persistence/examples/notes/application.rb
@@ -237,7 +237,7 @@ __END__
 <% @notes.each_with_hit do |note, hit|  %>
   <div class="note">
     <p>
-      <%= hit.highlight && hit.highlight.size > 0 ? hit.highlight.text.first : note.text %>
+      <%= hit[:highlight] && hit[:highlight].size > 0 ? hit[:highlight].text.first : note.text %>
 
       <% note.tags.each do |tag| %> <strong class="t"><%= tag %></strong><% end %>
       <small class="d"><%= Time.parse(note.created_at).strftime('%d/%m/%Y %H:%M') %></small>


### PR DESCRIPTION
- Since the branch name changes to main from master, `bundle install` was giving an error in elasticsearch-persistance app which is fixed with specifying branch name
- Fix the error `undefined method each_with_hit for Hash` 