### PR TITLE
Make the same request independently of the order that the models are loaded

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -42,7 +42,7 @@ module Elasticsearch
       # Returns an Array of registered models
       #
       def self.all
-        __instance.models
+        __instance.models.sort_by(&:name)
       end
 
       # Adds a model to the registry


### PR DESCRIPTION
Currently, the order of the index in  a search request changes
with the order that the models are loaded.

Problem: This does not matter for real rest request but
makes problems with mocks (E.g. VCR gem) on tests. The order of the tests can change
and in consequence the autoloader from rails loads models in a other order, causing that the
mock does not longer match since the order of indexes in the rest request not longer matches.