### PR TITLE
Improve ES::Model README suggestion for async indexing with after_save_commit

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -506,8 +506,8 @@ with a tool like [_Resque_](https://github.com/resque/resque) or [_Sidekiq_](htt
 class Article
   include Elasticsearch::Model
 
-  after_save    { Indexer.perform_async(:index,  self.id) }
-  after_destroy { Indexer.perform_async(:delete, self.id) }
+  after_save_commit { Indexer.perform_async(:index,  self.id) }
+  after_destroy     { Indexer.perform_async(:delete, self.id) }
 end
 ```
 


### PR DESCRIPTION
I got a lot of test failures using the original suggestion. First because newly created records weren't yet committed when the (test) worker ran, so I switched to `after_commit`. But `after_commit` also fires on destroy, so it would fail trying to reindex destroyed records. Rails 6 introduces `after_save_commit` for this purpose. Prior to Rails 6 it would be `after_commit ..., on: [:create, :update]`, but if you needed to change the next line to `after_commit ..., on: :destroy` the latter callback would clobber the former, and this prevents that.