### PR TITLE
[MODEL] Added functionality to provide custom value of total count for pagination

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination/kaminari.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination/kaminari.rb
@@ -106,10 +106,17 @@ module Elasticsearch
             self
           end
 
+          # Set the "total_count" value
+          #
+          def total(value)
+            @total_count = value.to_i
+            self
+          end
+
           # Returns the total number of results
           #
           def total_count
-            results.total
+            @total_count || results.total
           end
 
           # Returns the models's `per_page` value or the default

--- a/elasticsearch-model/lib/elasticsearch/model/response/pagination/will_paginate.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/pagination/will_paginate.rb
@@ -55,9 +55,11 @@ module Elasticsearch
             param_name = options[:param_name] || :page
             page       = [options[param_name].to_i, 1].max
             per_page   = (options[:per_page] || __default_per_page).to_i
+            total      = options[:total_entries]
 
             search.definition.update size: per_page,
                                      from: (page - 1) * per_page
+            @total_entries = total.to_i if total.present?
             self
           end
 
@@ -94,7 +96,7 @@ module Elasticsearch
           # Returns the total number of results
           #
           def total_entries
-            results.total
+            @total_entries || results.total
           end
 
           # Returns the models's `per_page` value or the default

--- a/elasticsearch-model/spec/elasticsearch/model/response/pagination/kaminari_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/pagination/kaminari_spec.rb
@@ -298,8 +298,20 @@ describe 'Elasticsearch::Model::Response::Response Kaminari' do
         allow(response.results).to receive(:total).and_return(100)
       end
 
-      it 'returns the total number of hits' do
-        expect(response.total_count).to eq(100)
+      context 'when a custom value is not set' do
+        it 'returns the total number of hits' do
+          expect(response.total_count).to eq(100)
+        end
+      end
+
+      context 'when a value is set via the #total method' do
+        before do
+          response.total(50)
+        end
+
+        it 'returns the total number of hits' do
+          expect(response.total_count).to eq(50)
+        end
       end
     end
 

--- a/elasticsearch-model/spec/elasticsearch/model/response/pagination/will_paginate_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/pagination/will_paginate_spec.rb
@@ -245,8 +245,20 @@ describe 'Elasticsearch::Model::Response::Response WillPaginate' do
         allow(response).to receive(:results).and_return(double('results', total: 100))
       end
 
-      it 'returns the total results' do
-        expect(response.total_entries).to eq(100)
+      context 'when a custom value is not set' do
+        it 'returns the total results' do
+          expect(response.total_entries).to eq(100)
+        end
+      end
+
+      context 'when a value is set via the #paginate method' do
+        before do
+          response.paginate(total_entries: 50)
+        end
+
+        it 'returns the total_entries value' do
+          expect(response.total_entries).to eq(50)
+        end
       end
     end
   end


### PR DESCRIPTION
### The Problem
When using [collapse parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html) to collapse search results, the total number of hits in the response indicates the number of matching documents **without collapsing**. As a result, the total number of pages for pagination is miscalculated.

For Example, the following query on the `group_items` index returns the total of 100 results without collapsing.

```sh
GET group_items/_search
{
  "query": {
    "match_all": {}
  }
}
```
But when the search results are collapsed based on the `group_id` field value. The total results returned by the query becomes only 5 instead of 100.

```sh
GET group_items/_search
{
  "query": {
    "match_all": {}
  },
  "collapse": {
    "field": "group_id"         
  }
}
```
The problem occurs when we paginate results, after collapsing, the value of the total number of hits is still 100 in response, as mentioned in the reference:

> The total number of hits in the response indicates the number of matching documents without collapsing. The total number of distinct groups is unknown.

### The solution
This problem with pagination can be solved by providing a custom value of `total_entries` (_will_paginate_) or `total_count` (_kaminari_).  The value of total distinct groups can be calculated by using [cardinality aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html)

```ruby
# Assuming a method `total_collapsed` is defined to get the total count of 
# collapsed results, using cardinality aggregation.
total_count = total_collapsed(response.aggregations)
```

Now to get pagination working correctly, the value of `total_count` can be specified.

```ruby
# for will_paginate
response.paginate(page: 1, per_page: 30, total_entries: total_count)

# for kaminari
response.page(1).total(total_count)
```

