### PR TITLE
Add ES 8.x support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -163,7 +163,7 @@ task :wait_for_green do
         ready = true
         break
       end
-    rescue Elasticsearch::Transport::Transport::Errors::RequestTimeout => ex
+    rescue ELASTIC_TRANSPORT_CLASS::Transport::Errors::RequestTimeout => ex
       puts "Couldn't confirm green status.\n#{ex.inspect}."
     rescue Faraday::ConnectionFailed => ex
       puts "Couldn't connect to Elasticsearch.\n#{ex.inspect}."

--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '> 3'
-  s.add_dependency 'elasticsearch', '~> 7'
+  s.add_dependency 'elasticsearch', '~> 8'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'activemodel', '> 3'

--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -61,6 +61,14 @@ when defined?(::WillPaginate)
   Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::WillPaginate
 end
 
+ELASTIC_TRANSPORT_CLASS =
+  begin
+    require 'elastic/transport'
+    Elastic::Transport
+  rescue LoadError
+    Elasticsearch::Transport
+  end
+
 module Elasticsearch
 
   # Elasticsearch integration for Ruby models

--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -163,7 +163,7 @@ module Elasticsearch
               index: target_index,
               type:  target_type,
               body:  __batch_to_bulk(batch, transform)
-            }
+            }.compact
 
             params[:pipeline] = pipeline if pipeline
 

--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -90,7 +90,7 @@ module Elasticsearch
 
       # Get the client common for all models
       #
-      # @return Elasticsearch::Transport::Client
+      # @return Elastic::Transport::Client
       #
       def client
         Elasticsearch::Model.client

--- a/elasticsearch-model/lib/elasticsearch/model/searching.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/searching.rb
@@ -54,9 +54,9 @@ module Elasticsearch
           end
 
           if body
-            @definition = { index: __index_name, type: __document_type, body: body }.update options
+            @definition = { index: __index_name, type: __document_type, body: body }.compact.update options
           else
-            @definition = { index: __index_name, type: __document_type, q: q }.update options
+            @definition = { index: __index_name, type: __document_type, q: q }.compact.update options
           end
         end
 

--- a/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
@@ -678,7 +678,7 @@ describe Elasticsearch::Model::Indexing do
     context 'when the index is not found' do
       let(:logger) { nil }
       let(:transport) do
-        Elasticsearch::Transport::Client.new(logger: logger)
+        ELASTIC_TRANSPORT_CLASS::Client.new(logger: logger)
       end
 
       let(:client) do
@@ -918,7 +918,7 @@ describe Elasticsearch::Model::Indexing do
     end
 
     let(:transport) do
-      Elasticsearch::Transport::Client.new(logger: nil)
+      ELASTIC_TRANSPORT_CLASS::Client.new(logger: nil)
     end
 
     let(:indices) do
@@ -949,7 +949,7 @@ describe Elasticsearch::Model::Indexing do
           end
 
           let(:transport) do
-            Elasticsearch::Transport::Client.new(logger: logger)
+            ELASTIC_TRANSPORT_CLASS::Client.new(logger: logger)
           end
 
           it 'does not raise an exception' do

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "elasticsearch",       '~> 7'
+  s.add_dependency "elasticsearch",       '~> 8'
   s.add_dependency "elasticsearch-model", '7.2.1'
   s.add_dependency "activesupport",       '> 4'
   s.add_dependency "activemodel",         '> 4'

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
@@ -87,7 +87,7 @@ module Elasticsearch
           request[:type] = document_type if document_type
           document = client.get(request.merge(options))
           deserialize(document)
-        rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        rescue ELASTIC_TRANSPORT_CLASS::Transport::Errors::NotFound => e
           raise DocumentNotFound, e.message, caller
         end
 

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
@@ -61,7 +61,7 @@ module Elasticsearch
         #
         def search(query_or_definition, options={})
           request = { index: index_name,
-                      type: document_type }
+                      type: document_type }.compact
           if query_or_definition.respond_to?(:to_hash)
             request[:body] = query_or_definition.to_hash
           elsif query_or_definition.is_a?(String)
@@ -99,7 +99,7 @@ module Elasticsearch
         def count(query_or_definition=nil, options={})
           query_or_definition ||= { query: { match_all: {} } }
           request = { index: index_name,
-                      type: document_type }
+                      type: document_type }.compact
 
           if query_or_definition.respond_to?(:to_hash)
             request[:body] = query_or_definition.to_hash

--- a/elasticsearch-persistence/spec/repository/store_spec.rb
+++ b/elasticsearch-persistence/spec/repository/store_spec.rb
@@ -242,7 +242,7 @@ describe Elasticsearch::Persistence::Repository::Store do
         it 'raises an exception' do
           expect {
             repository.update(1, doc: { text: 'testing_2' })
-          }.to raise_exception(Elasticsearch::Transport::Transport::Errors::NotFound)
+          }.to raise_exception(ELASTIC_TRANSPORT_CLASS::Transport::Errors::NotFound)
         end
 
         context 'when upsert is provided' do
@@ -262,7 +262,7 @@ describe Elasticsearch::Persistence::Repository::Store do
         it 'raises an exception' do
           expect {
             repository.update(id: 1, text: 'testing_2')
-          }.to raise_exception(Elasticsearch::Transport::Transport::Errors::NotFound)
+          }.to raise_exception(ELASTIC_TRANSPORT_CLASS::Transport::Errors::NotFound)
         end
 
         context 'when upsert is provided' do
@@ -337,7 +337,7 @@ describe Elasticsearch::Persistence::Repository::Store do
       it 'raises an exception' do
         expect {
           repository.delete(1)
-        }.to raise_exception(Elasticsearch::Transport::Transport::Errors::NotFound)
+        }.to raise_exception(ELASTIC_TRANSPORT_CLASS::Transport::Errors::NotFound)
       end
     end
   end

--- a/elasticsearch-persistence/spec/repository_spec.rb
+++ b/elasticsearch-persistence/spec/repository_spec.rb
@@ -562,7 +562,7 @@ describe Elasticsearch::Persistence::Repository do
             it 'raises an error' do
               expect {
                 repository.create_index!
-              }.to raise_exception(Elasticsearch::Transport::Transport::Errors::BadRequest)
+              }.to raise_exception(ELASTIC_TRANSPORT_CLASS::Transport::Errors::BadRequest)
             end
           end
         end


### PR DESCRIPTION
In addition to pinning v8 of `elasticsearch-ruby`, there were two other things I had to consider.

ES 8 does not allow sending a document type. I followed previous work in this repo and used `Hash#compact` to remove the `type` param.

`elasticsearch-ruby` v8 uses the new `elastic-transport` gem instead of the older `elasticsearch-transport` one. I added a (hopefully) backwards compatible solution via `ELASTIC_TRANSPORT_CLASS`.