### PR TITLE
Use self.client instead of client

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/indexing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/indexing.rb
@@ -290,7 +290,7 @@ module Elasticsearch
             self.client.indices.delete index: target_index
           rescue Exception => e
             if e.class.to_s =~ /NotFound/ && options[:force]
-              client.transport.transport.logger.debug("[!!!] Index does not exist (#{e.class})") if client.transport.transport.logger
+              self.client.transport.transport.logger.debug("[!!!] Index does not exist (#{e.class})") if self.client.transport.transport.logger
               nil
             else
               raise e


### PR DESCRIPTION
Should fix https://github.com/elastic/elasticsearch-rails/issues/1004 (also mentioned here https://github.com/elastic/elasticsearch-ruby/issues/1344#issuecomment-1017176417)

When deleting an index that doesn't exist, the exception handler references `client` but I think it should be referencing `self.client`