### PR TITLE
Fix missing environment dependency for import tasks

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/tasks/import.rb
@@ -57,7 +57,7 @@ namespace :elasticsearch do
         $ rake environment elasticsearch:import:model CLASS='Article' SCOPE='published'
     DESC
     desc import_model_desc
-    task :model do
+    task model: :environment do
       if ENV['CLASS'].to_s == ''
         puts '='*90, 'USAGE', '='*90, import_model_desc, ""
         exit(1)
@@ -97,7 +97,7 @@ namespace :elasticsearch do
 
         $ rake environment elasticsearch:import:all DIR=app/models
     DESC
-    task :all do
+    task all: :environment do
       dir    = ENV['DIR'].to_s != '' ? ENV['DIR'] : Rails.root.join("app/models")
 
       puts "[IMPORT] Loading models from: #{dir}"


### PR DESCRIPTION
For tasks to work properly (i.e., find the models) the tasks need to have a dependency on the environment task (bootstraps the environment). Without this, the import tasks fail (e.g. `NameError: uninitialized constant User`).

Fixes https://github.com/elastic/elasticsearch-rails/issues/971 (and related issues)