### PR TITLE
renamed docker image name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can generate a simple Ruby on Rails application with a single command
     --env "cluster.name=elasticsearch-rails" \
     --env "cluster.routing.allocation.disk.threshold_enabled=false" \
     --rm \
-    docker.elastic.co/elasticsearch/elasticsearch-oss:7.6.0
+    docker.elastic.co/elasticsearch/elasticsearch:7.6.0
 ```
 
 Once Elasticsearch is running, you can generate the simple app with this command:


### PR DESCRIPTION
When building an Elasticsearch environment in Docker according to the usage, the following error occurs when generating the sample rails application.

```
rails runner 'Article.__elasticsearch__.create_index! force: true' from "."
/Users/username/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/elasticsearch-7.17.7/lib/elasticsearch.rb:86:in `verify_with_version_or_header': The client noticed that the server is not a supported distribution of Elasticsearch. (Elasticsearch::UnsupportedProductError)
```

This is because the elasticsearch-ruby gem no longer supports oss only distributions.

https://github.com/elastic/elasticsearch-ruby/issues/1429

To avoid unnecessary errors, we suggest changing the name of the Docker Image for testing, which is introduced in Usage.

version control software: asdf
ruby version: 3.1.2