### PR TITLE
Add compatibility with Ruby 3 for 6.x

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -90,15 +90,18 @@ module Elasticsearch
           @target = target
         end
 
-        # Delegate methods to `@target`
+        def ruby2_keywords(*) # :nodoc:
+        end if RUBY_VERSION < "2.7"
+
+        # Delegate methods to `@target`. As per [the Ruby 3.0 explanation for keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), the only way to work on Ruby <2.7, and 2.7, and 3.0+ is to use `ruby2_keywords`.
         #
-        def method_missing(method_name, *arguments, &block)
+        ruby2_keywords def method_missing(method_name, *arguments, &block)
           target.respond_to?(method_name) ? target.__send__(method_name, *arguments, &block) : super
         end
 
         # Respond to methods from `@target`
         #
-        def respond_to?(method_name, include_private = false)
+        def respond_to_missing?(method_name, include_private = false)
           target.respond_to?(method_name) || super
         end
 

--- a/elasticsearch-model/spec/elasticsearch/model/proxy_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/proxy_spec.rb
@@ -14,6 +14,10 @@ describe Elasticsearch::Model::Proxy do
         'insta barr'
       end
 
+      def keyword_method(foo: 'default value')
+        foo
+      end
+
       def as_json(options)
         {foo: 'bar'}
       end
@@ -103,5 +107,9 @@ describe Elasticsearch::Model::Proxy do
       expect(model).to eq(model_target)
       expect(duplicate).to eq(duplicate_target)
     end
+  end
+
+  it 'forwards keyword arguments to target methods' do
+    expect(DummyProxyModel.new.__elasticsearch__.keyword_method(foo: 'bar')).to eq('bar')
   end
 end


### PR DESCRIPTION
This is the same change made in https://github.com/elastic/elasticsearch-rails/pull/992, but for version 6.x, to enable support for Ruby 3

All credit for this fix goes to @indirect, I just copy-pasted that code over.