### PR TITLE
WIP: Elasticsearch 8.7.x

### DIFF
--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -27,7 +27,8 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 8.7.0-SNAPSHOT
+        stack-version: 8.8.0-SNAPSHOT
+        security-enabled: false
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.x-SNAPSHOT
+        stack-version: 8.7.0-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -27,7 +27,8 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 8.7.0-SNAPSHOT
+        stack-version: 8.8.0-SNAPSHOT
+        security-enabled: false
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.x-SNAPSHOT
+        stack-version: 8.7.0-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -27,7 +27,8 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 8.7.0-SNAPSHOT
+        stack-version: 8.8.0-SNAPSHOT
+        security-enabled: false
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.3

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 7.x-SNAPSHOT
+        stack-version: 8.7.0-SNAPSHOT
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.3

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ source 'https://rubygems.org'
 
 gem 'ansi'
 gem 'cane'
-gem 'elasticsearch', '~> 7'
+gem 'elasticsearch', '~> 8.7.0'
 gem 'pry'
 gem 'rake', '~> 12'
 

--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '> 3'
-  s.add_dependency 'elasticsearch', '~> 7'
+  s.add_dependency 'elasticsearch', '~> 8'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'activemodel', '> 3'

--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake', '~> 12'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'require-prof'
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov'

--- a/elasticsearch-model/lib/elasticsearch/model/importing.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/importing.rb
@@ -161,7 +161,6 @@ module Elasticsearch
           __find_in_batches(options) do |batch|
             params = {
               index: target_index,
-              type:  target_type,
               body:  __batch_to_bulk(batch, transform)
             }
 

--- a/elasticsearch-model/lib/elasticsearch/model/version.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Model
-    VERSION = "7.2.1"
+    VERSION = "8.7.0"
   end
 end

--- a/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/basic_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/basic_spec.rb
@@ -67,7 +67,7 @@ describe Elasticsearch::Model::Adapter::ActiveRecord do
       end
 
       Article.delete_all
-      Article.__elasticsearch__.create_index!(force: true, include_type_name: true)
+      Article.__elasticsearch__.create_index!(force: true)
 
       Article.create!(title: 'Test', body: '', clicks: 1)
       Article.create!(title: 'Testing Coding', body: '', clicks: 2)

--- a/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/namespaced_model_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/namespaced_model_spec.rb
@@ -27,7 +27,7 @@ describe 'Elasticsearch::Model::Adapter::ActiveRecord Namespaced Model' do
     end
 
     MyNamespace::Book.delete_all
-    MyNamespace::Book.__elasticsearch__.create_index!(force: true, include_type_name: true)
+    MyNamespace::Book.__elasticsearch__.create_index!(force: true)
     MyNamespace::Book.create!(title: 'Test')
     MyNamespace::Book.__elasticsearch__.refresh_index!
   end

--- a/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/parent_child_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/adapters/active_record/parent_child_spec.rb
@@ -38,7 +38,7 @@ describe 'Elasticsearch::Model::Adapter::ActiveRecord Parent-Child' do
       add_index(:answers, :question_id) unless index_exists?(:answers, :question_id)
 
       clear_tables(Question)
-      ParentChildSearchable.create_index!(force: true, include_type_name: true)
+      ParentChildSearchable.create_index!(force: true)
 
       q_1 = Question.create!(title: 'First Question',  author: 'John')
       q_2 = Question.create!(title: 'Second Question', author: 'Jody')

--- a/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
@@ -131,25 +131,6 @@ describe Elasticsearch::Model::Indexing do
       it 'uses text as the default field type' do
         expect(mappings.to_hash[:mytype][:properties][:bar][:type]).to eq('text')
       end
-
-      context 'when the \'include_type_name\' option is specified' do
-
-        let(:mappings) do
-          Elasticsearch::Model::Indexing::Mappings.new(:mytype, include_type_name: true)
-        end
-
-        before do
-          mappings.indexes :foo, { type: 'boolean', include_in_all: false }
-        end
-
-        it 'creates the correct mapping definition' do
-          expect(mappings.to_hash[:mytype][:properties][:foo][:type]).to eq('boolean')
-        end
-
-        it 'sets the \'include_type_name\' option' do
-          expect(mappings.to_hash[:mytype][:include_type_name]).to eq(true)
-        end
-      end
     end
 
     context 'when a type is not specified' do
@@ -175,7 +156,7 @@ describe Elasticsearch::Model::Indexing do
     context 'when specific mappings are defined' do
 
       let(:mappings) do
-        Elasticsearch::Model::Indexing::Mappings.new(:mytype, include_type_name: true)
+        Elasticsearch::Model::Indexing::Mappings.new(:mytype)
       end
 
       before do

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'oj' unless defined?(JRUBY_VERSION)
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rails', '> 4'
+  s.add_development_dependency 'rails', '~> 7'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION)
   s.add_development_dependency 'shoulda-context'

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -43,8 +43,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel',         '> 4'
   s.add_dependency 'activesupport',       '> 4'
-  s.add_dependency 'elasticsearch',       '~> 7'
-  s.add_dependency 'elasticsearch-model', '7.2.1'
+  s.add_dependency 'elasticsearch',       '~> 8'
+  s.add_dependency 'elasticsearch-model', '8.7.0'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'bundler'

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/find.rb
@@ -64,7 +64,6 @@ module Elasticsearch
         #
         def exists?(id, options={})
           request = { index: index_name, id: id }
-          request[:type] = document_type if document_type
           client.exists(request.merge(options))
         end
 
@@ -84,7 +83,6 @@ module Elasticsearch
         #
         def __find_one(id, options={})
           request = { index: index_name, id: id }
-          request[:type] = document_type if document_type
           document = client.get(request.merge(options))
           deserialize(document)
         rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
@@ -95,7 +93,6 @@ module Elasticsearch
         #
         def __find_many(ids, options={})
           request = { index: index_name, body: { ids: ids } }
-          request[:type] = document_type if document_type
           documents = client.mget(request.merge(options))
           documents[DOCS].map do |document|
             deserialize(document) if document[FOUND]

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/search.rb
@@ -60,8 +60,7 @@ module Elasticsearch
         # @return [Elasticsearch::Persistence::Repository::Response::Results]
         #
         def search(query_or_definition, options={})
-          request = { index: index_name,
-                      type: document_type }
+          request = { index: index_name }
           if query_or_definition.respond_to?(:to_hash)
             request[:body] = query_or_definition.to_hash
           elsif query_or_definition.is_a?(String)

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
@@ -40,7 +40,6 @@ module Elasticsearch
           request = { index: index_name,
                       id: id,
                       body: serialized }
-          request[:type] = document_type if document_type
           client.index(request.merge(options))
         end
 
@@ -76,7 +75,7 @@ module Elasticsearch
             end
             type = document.delete(:type) || document_type
           end
-          client.update(index: index_name, id: id, type: type, body: body)
+          client.update(index: index_name, id: id, body: body)
         end
 
         # Remove the serialized object or document with specified ID from Elasticsearch

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/repository/store.rb
@@ -97,7 +97,7 @@ module Elasticsearch
             serialized = serialize(document_or_id)
             id = __get_id_from_document(serialized)
           end
-          client.delete({ index: index_name, type: document_type, id: id }.merge(options))
+          client.delete({ index: index_name, id: id }.merge(options))
         end
       end
     end

--- a/elasticsearch-persistence/spec/repository/store_spec.rb
+++ b/elasticsearch-persistence/spec/repository/store_spec.rb
@@ -331,7 +331,7 @@ describe Elasticsearch::Persistence::Repository::Store do
     context 'when the document does not exist' do
 
       before do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!()
       end
 
       it 'raises an exception' do

--- a/elasticsearch-persistence/spec/repository_spec.rb
+++ b/elasticsearch-persistence/spec/repository_spec.rb
@@ -279,7 +279,7 @@ describe Elasticsearch::Persistence::Repository do
 
         before do
           begin; repository.delete_index!; rescue; end
-          repository.create_index!(include_type_name: true)
+          repository.create_index!()
         end
 
         it 'creates the index' do
@@ -334,7 +334,7 @@ describe Elasticsearch::Persistence::Repository do
         end
 
         before do
-          repository.create_index!(include_type_name: true)
+          repository.create_index!()
         end
 
         it 'refreshes the index' do
@@ -361,7 +361,7 @@ describe Elasticsearch::Persistence::Repository do
         end
 
         before do
-          repository.create_index!(include_type_name: true)
+          repository.create_index!()
         end
 
         it 'determines if the index exists' do
@@ -549,14 +549,6 @@ describe Elasticsearch::Persistence::Repository do
 
         context 'when the server is version >= 7.0', if: server_version > '7.0' do
 
-          context 'when the include_type_name option is specified' do
-
-            it 'creates an index' do
-              repository.create_index!(include_type_name: true)
-              expect(repository.index_exists?).to eq(true)
-            end
-          end
-
           context 'when the include_type_name option is not specified' do
 
             it 'raises an error' do
@@ -582,7 +574,7 @@ describe Elasticsearch::Persistence::Repository do
       end
 
       it 'deletes an index' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!()
         repository.delete_index!
         expect(repository.index_exists?).to eq(false)
       end
@@ -605,7 +597,7 @@ describe Elasticsearch::Persistence::Repository do
       end
 
       it 'refreshes an index' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!()
         expect(repository.refresh_index!['_shards']).to be_a(Hash)
       end
     end
@@ -627,7 +619,7 @@ describe Elasticsearch::Persistence::Repository do
       end
 
       it 'returns whether the index exists' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!()
         expect(repository.index_exists?).to be(true)
       end
     end

--- a/elasticsearch-rails/elasticsearch-rails.gemspec
+++ b/elasticsearch-rails/elasticsearch-rails.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rails', '> 3.1'
+  s.add_development_dependency 'rails', '~> 7'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'require-prof'
   s.add_development_dependency 'shoulda-context'


### PR DESCRIPTION
It's draft version of attempt to check what should be done to make elasticsearch-rails work with new elasticsearch-ruby 8.7.x and faraday 2.x. I'm not too deep dived in this gems, but I use it in my pet project. So I decided to try.

This links could help during development:

https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0
https://github.com/elastic/elasticsearch-rails/pull/1048
https://github.com/elastic/elasticsearch-rails/pull/1025
https://github.com/elastic/elasticsearch-rails/issues/1049

If you have some thoughts/knowledge how to bring this PR to life faster/better, then let me know.