### PR TITLE
[MODEL] Update README. `7.x` is supported.

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -16,6 +16,7 @@ The version numbers follow the Elasticsearch major versions. Currently the `main
 | 2.x           | → | 2.x           |
 | 5.x           | → | 5.x           |
 | 6.x           | → | 6.x           |
+| 7.x           | → | 7.x           |
 | main          | → | 7.x           |
 
 ## Installation


### PR DESCRIPTION
Although https://github.com/elastic/elasticsearch-rails/tree/main/elasticsearch-model#compatibility says that `7.x` tag is not supported, `7.x` has been supported by https://github.com/elastic/elasticsearch-rails/commit/a0f14d96fab54b64cb3b8cbacd6476aba2dfa78d .
Then, I update README.

ref
* https://github.com/elastic/elasticsearch-rails/tree/main/elasticsearch-persistence#compatibility
* https://github.com/elastic/elasticsearch-rails/tree/main/elasticsearch-rails#compatibility