### PR TITLE
Fix deprecation warning from Rails 7.2, use kwarg for bold option in log subscriber

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
@@ -47,7 +47,7 @@ module Elasticsearch
           name    = "#{payload[:klass]} #{payload[:name]} (#{event.duration.round(1)}ms)"
           search  = payload[:search].inspect.gsub(/:(\w+)=>/, '\1: ')
 
-          debug %Q|  #{color(name, GREEN, true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
+          debug %Q|  #{color(name, GREEN, bold: true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
         end
       end
 


### PR DESCRIPTION
### Why?

Fixes this warning

> DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. color("my text", :red, bold: true))

This stems from the use of the color function in `log_subscriber.rb`
