### PR TITLE
Updated project metadata to use group email address

### DIFF
--- a/elasticsearch-model/elasticsearch-model.gemspec
+++ b/elasticsearch-model/elasticsearch-model.gemspec
@@ -24,8 +24,8 @@ require 'elasticsearch/model/version'
 Gem::Specification.new do |s|
   s.name          = 'elasticsearch-model'
   s.version       = Elasticsearch::Model::VERSION
-  s.authors       = ['Karel Minarik']
-  s.email         = ['support@elastic.co']
+  s.authors       = ['Elastic Client Library Maintainers']
+  s.email         = ['client-libs@elastic.co']
   s.description   = 'ActiveModel/Record integrations for Elasticsearch.'
   s.summary       = 'ActiveModel/Record integrations for Elasticsearch.'
   s.homepage      = 'https://github.com/elasticsearch/elasticsearch-rails/'

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -24,8 +24,8 @@ require 'elasticsearch/persistence/version'
 Gem::Specification.new do |s|
   s.name          = 'elasticsearch-persistence'
   s.version       = Elasticsearch::Persistence::VERSION
-  s.authors       = ['Karel Minarik']
-  s.email         = ['support@elastic.co']
+  s.authors       = ['Elastic Client Library Maintainers']
+  s.email         = ['client-libs@elastic.co']
   s.description   = 'Persistence layer for Ruby models and Elasticsearch.'
   s.summary       = 'Persistence layer for Ruby models and Elasticsearch.'
   s.homepage      = 'https://github.com/elasticsearch/elasticsearch-rails/'

--- a/elasticsearch-rails/elasticsearch-rails.gemspec
+++ b/elasticsearch-rails/elasticsearch-rails.gemspec
@@ -23,8 +23,8 @@ require 'elasticsearch/rails/version'
 Gem::Specification.new do |s|
   s.name          = 'elasticsearch-rails'
   s.version       = Elasticsearch::Rails::VERSION
-  s.authors       = ['Karel Minarik']
-  s.email         = ['support@elastic.co']
+  s.authors       = ['Elastic Client Library Maintainers']
+  s.email         = ['client-libs@elastic.co']
   s.description   = 'Ruby on Rails integrations for Elasticsearch.'
   s.summary       = 'Ruby on Rails integrations for Elasticsearch.'
   s.homepage      = 'https://github.com/elasticsearch/elasticsearch-rails/'


### PR DESCRIPTION
This PR removes individual names and email addresses and replaces those with the new (external) [group email address](mailto:client-libs@elastic.co).