### PR TITLE
Addressing #838, STI issues when code is reloaded in development, fix…

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/adapters/multiple.rb
@@ -106,16 +106,16 @@ module Elasticsearch
           # @api private
           #
           def __type_for_hit(hit)
-            @@__types ||= {}
 
             key = "#{hit[:_index]}::#{hit[:_type]}" if hit[:_type] && hit[:_type] != '_doc'
             key = hit[:_index] unless key
 
-            @@__types[key] ||= begin
-              Registry.all.detect do |model|
-                (model.index_name == hit[:_index] && __no_type?(hit)) ||
-                    (model.index_name == hit[:_index] && model.document_type == hit[:_type])
-              end
+            # DVB -- not sure the ramifications of this - but do not memoize the model/klass
+            # I do not think that caching the types is necessary, minimal processing savings
+            # at the expense of broken STI autoloading in development, see #848
+            Registry.all.detect do |model|
+              (model.index_name == hit[:_index] && __no_type?(hit)) ||
+                  (model.index_name == hit[:_index] && model.document_type == hit[:_type])
             end
           end
 

--- a/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/multimodel.rb
@@ -48,7 +48,12 @@ module Elasticsearch
       # Adds a model to the registry
       #
       def add(klass)
-        @models << klass
+        # Detect already loaded models and ensure that a duplicate is not stored
+        if i = @models.index{ |_class| _class.name == klass.name }
+          @models[i] = klass
+        else
+          @models << klass
+        end
       end
 
       # Returns a copy of the registered models


### PR DESCRIPTION
The class level map using @@__types messes up the autoloading when STI classes are present.  The Registry.all.detect lookup should be very fast so this seems to be a good trade off to fix the old STI auto load issue that was reported in #838 and closed by the stalebot.  

Related PR #888 was also closed with a statement that STI support is deprecated and removed from the gem.  It is my opinion that this PR and #888 is a fix related to Rails autoloading and has nothing to do with STI support.   

Please consider this PR to close #848 for good.   Thanks!