### PR TITLE
`ruby2_keywords` is not an instance method

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -115,7 +115,7 @@ module Elasticsearch
           @target = target
         end
 
-        def ruby2_keywords(*) # :nodoc:
+        def self.ruby2_keywords(*) # :nodoc:
         end if RUBY_VERSION < "2.7"
 
         # Delegate methods to `@target`. As per [the Ruby 3.0 explanation for keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), the only way to work on Ruby <2.7, and 2.7, and 3.0+ is to use `ruby2_keywords`.


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-rails/blob/8fe0a555083d16d9d64dea7b0ae8a8695c1d4211/elasticsearch-model/lib/elasticsearch/model/proxy.rb#L118 defines an instance method.
But https://github.com/elastic/elasticsearch-rails/blob/8fe0a555083d16d9d64dea7b0ae8a8695c1d4211/elasticsearch-model/lib/elasticsearch/model/proxy.rb#L123 calls a class method.
So it should define as a singleton method of the module.
