### PR TITLE
Satisfy all tests on 8.x branch

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/proxy.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/proxy.rb
@@ -61,7 +61,7 @@ module Elasticsearch
 
           # Mix the importing module into the `ClassMethodsProxy`
           self.__elasticsearch__.class_eval do
-            include Adapter.from_class(base).importing_mixin
+            extend Adapter.from_class(base).importing_mixin
           end
 
           # Register a callback for storing changed attributes for models which implement

--- a/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/indexing_spec.rb
@@ -591,7 +591,7 @@ describe Elasticsearch::Model::Indexing do
 
     context 'when the index is not found' do
       let(:logger) { nil }
-      let(:client) { Elasticsearch::Client.new(logger: logger) }
+      let(:client) { Elasticsearch::Client.new(logger: logger, transport_options: { ssl: { verify: false } }) }
 
       before do
         expect(DummyIndexingModelForRecreate).to receive(:client).at_most(3).times.and_return(client)

--- a/elasticsearch-model/spec/spec_helper.rb
+++ b/elasticsearch-model/spec/spec_helper.rb
@@ -45,7 +45,8 @@ RSpec.configure do |config|
     tracer.formatter = lambda { |s, d, p, m| "#{m.gsub(/^.*$/) { |n| '   ' + n }.ansi(:faint)}\n" }
     Elasticsearch::Model.client = Elasticsearch::Client.new(
       host: ELASTICSEARCH_URL,
-      tracer: (ENV['QUIET'] ? nil : tracer)
+      tracer: (ENV['QUIET'] ? nil : tracer),
+      transport_options: { :ssl => { verify: false } }
     )
     puts "Elasticsearch Version: #{Elasticsearch::Model.client.info['version']}"
 

--- a/elasticsearch-persistence/spec/spec_helper.rb
+++ b/elasticsearch-persistence/spec/spec_helper.rb
@@ -36,7 +36,8 @@ end
 #
 # @since 6.0.0
 DEFAULT_CLIENT = Elasticsearch::Client.new(host: ELASTICSEARCH_URL,
-                                           tracer: (ENV['QUIET'] ? nil : ::Logger.new(STDERR)))
+                                           tracer: (ENV['QUIET'] ? nil : ::Logger.new(STDERR)),
+                                           transport_options: { :ssl => { verify: false } })
 
 class MyTestRepository
   include Elasticsearch::Persistence::Repository

--- a/elasticsearch-rails/spec/spec_helper.rb
+++ b/elasticsearch-rails/spec/spec_helper.rb
@@ -36,7 +36,8 @@ RSpec.configure do |config|
     tracer = ::Logger.new(STDERR)
     tracer.formatter = lambda { |s, d, p, m| "#{m.gsub(/^.*$/) { |n| '   ' + n }.ansi(:faint)}\n" }
     Elasticsearch::Model.client = Elasticsearch::Client.new host: ELASTICSEARCH_URL,
-                                                            tracer: (ENV['QUIET'] ? nil : tracer)
+                                                            tracer: (ENV['QUIET'] ? nil : tracer),
+                                                            transport_options: { :ssl => { verify: false } }
     puts "Elasticsearch Version: #{Elasticsearch::Model.client.info['version']}"
 
     unless ActiveRecord::Base.connected?


### PR DESCRIPTION
I found this conversation ( https://github.com/elastic/elasticsearch-rails/pull/1056 ) which led me to the unreleased 8.x branch, but the tests are currently failing.

This pull request makes as few changes as possible in order to make all unit tests pass when running `rake test:all` from the project root.

The first commit makes some changes that I found necessary in order to connect to Elasticsearch 8.13.2 running in Docker on my local machine. It...
* disables SSL certificate validation so that the self-signed certificates can be used out-of-the-box
* changes the startup script to wait for either yellow or green status, as a single ES node is yellow for me under Docker. According to the ES documentation yellow means, "All primary shards are assigned, but one or more replica shards are unassigned." (https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html) This strikes me as a valid state for a test environment so I included this change in the commit.
* Fixes an apparently broken reference to `CERT_DIR`. Since I'm not sure of the history of this constant, I decided to check if it is available using `defined?(CERT_DIR)` and then only omit the option if the constant is not found, using it as before if it exists.

The second commit actually fixes the tests. There was only one logic change needed.
* The `ClassMethodsProxy` needed to use `extend` on the adapter methods, rather than `include`.

I hope that with passing tests we may see a formal 8.x release soon. I am not clear on what else needs to be done but am available to contribute more if needed.