### PR TITLE
Release 8.0.0.pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 8.0.0.pre
+
+### General:
+
+First pre-release for `8.0.0`. Major versions of `8.x` will support Elasticsearch version `8.x` changing the `elasticsearch` dependency's major version: `gem 'elasticsearch', '~> 8'`.
+
+All references to `type` should have been removed. Document types were deprecated and do not exist in `8.x`.
+
+The dependency from `elasticsearch` on `elasticsearch-transport` was updated to `elastic-transport`. All `8.x` Elasticsearch APIs supported by `elasticsearch` should now be supported on the Rails library. See [Release notes for the Elasticsearch client 8.0](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/release_notes_80.html) and the [8.x release notes](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/release_notes.html#_8_x) for more information.
+
+### Compatibility
+
+The gem is currently testing with Ruby 3.1, 3.2 and 3.3 and JRuby 9.4. Testing for Ruby `2.x` versions has been dropped as they're no longer updated or supported. Currently testing with Rails 6.1, 7.0 and 7.1.
+
+### Development changes
+
+- Using `debug` for debugging in `development` and `testing` Gemfile groups.
+- Minor general code cleanups and styling changes.
+- Updated code to for `elasticsearch` 8.x.
+
 ## 7.2.1
 
 * The default git branch `master` has been renamed to `main`

--- a/elasticsearch-model/lib/elasticsearch/model/version.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Model
-    VERSION = '8.0.0'.freeze
+    VERSION = '8.0.0.pre'.freeze
   end
 end

--- a/elasticsearch-persistence/elasticsearch-persistence.gemspec
+++ b/elasticsearch-persistence/elasticsearch-persistence.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel',         '> 4'
   s.add_dependency 'activesupport',       '> 4'
   s.add_dependency 'elasticsearch',       '~> 8'
-  s.add_dependency 'elasticsearch-model', '8'
+  s.add_dependency 'elasticsearch-model', '8.0.0.pre'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'bundler'

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/version.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Persistence
-    VERSION = '8.0.0'.freeze
+    VERSION = '8.0.0.pre'.freeze
   end
 end

--- a/elasticsearch-rails/lib/elasticsearch/rails/version.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Rails
-    VERSION = '8.0.0'.freeze
+    VERSION = '8.0.0.pre'.freeze
   end
 end


### PR DESCRIPTION
### General:

First pre-release for `8.0.0`. Major versions of `8.x` will support Elasticsearch version `8.x` changing the `elasticsearch` dependency's major version: `gem 'elasticsearch', '~> 8'`.

All references to `type` should have been removed. Document types were deprecated and do not exist in `8.x`.

The dependency from `elasticsearch` on `elasticsearch-transport` was updated to `elastic-transport`. All `8.x` Elasticsearch APIs supported by `elasticsearch` should now be supported on the Rails library. See [Release notes for the Elasticsearch client 8.0](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/release_notes_80.html) and the [8.x release notes](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/release_notes.html#_8_x) for more information.

### Compatibility

The gem is currently testing with Ruby 3.1, 3.2 and 3.3 and JRuby 9.4. Support for Ruby `2.x` has been dropped as they're no longer updated or supported. Currently testing with Rails 6.1, 7.0 and 7.1.

### Development changes

- Using `debug` for debugging in `development` and `testing` Gemfile groups.
- Minor general code cleanups and styling changes.
- Updated code to for `elasticsearch` 8.x.

