### PR TITLE
Address Rails 7.1 deprecation warning in elasticsearch-rails (for 7.x branch)

### DIFF
--- a/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
+++ b/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/log_subscriber.rb
@@ -46,8 +46,19 @@ module Elasticsearch
           payload = event.payload
           name    = "#{payload[:klass]} #{payload[:name]} (#{event.duration.round(1)}ms)"
           search  = payload[:search].inspect.gsub(/:(\w+)=>/, '\1: ')
+          debug %Q|  #{color(name, GREEN, color_option(true))} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
+        end
 
-          debug %Q|  #{color(name, GREEN, true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
+        private
+
+        def color_option(bold_value)
+          new_color_syntax? ? { bold: bold_value } : bold_value
+        end
+
+        def new_color_syntax?
+          return @new_color_syntax if defined?(@new_color_syntax)
+
+          @new_color_syntax = ::Rails.respond_to?(:gem_version) && ::Rails.gem_version >= '7.1'
         end
       end
 

--- a/elasticsearch-rails/spec/instrumentation/log_subscriber_spec.rb
+++ b/elasticsearch-rails/spec/instrumentation/log_subscriber_spec.rb
@@ -1,0 +1,57 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'elasticsearch/rails/instrumentation/log_subscriber'
+
+describe Elasticsearch::Rails::Instrumentation::LogSubscriber do
+  subject(:instance) { described_class.new }
+
+  let(:logger) { instance_double(Logger) }
+
+  before do
+    allow(instance).to receive(:logger) { logger }
+  end
+
+  describe "#search" do
+    subject { instance.search(event) }
+
+    let(:event) { double("search.elasticsearch", duration: 1.2345, payload: { name: "execute", search: { query: { match_all: {}}}}) }
+
+    it "logs the event" do
+      expect(instance).to receive(:color).with(" execute (1.2ms)", described_class::GREEN, { bold: true }).and_call_original
+      expect(logger).to receive(:debug?) { true }
+      expect(logger).to receive(:debug).with("  \e[1m\e[32m execute (1.2ms)\e[0m \e[2m{query: {match_all: {}}}\e[0m")
+      subject
+    end
+
+    context "when Rails version is older" do
+      let(:rails_version) { "7.0.0" }
+
+      before do
+        allow(::Rails).to receive(:gem_version) { Gem::Version.new(rails_version) }
+      end
+
+      it "logs the event" do
+        expect(instance).to receive(:color).with(" execute (1.2ms)", described_class::GREEN, true).and_call_original
+        expect(logger).to receive(:debug?) { true }
+        expect(logger).to receive(:debug).with("  \e[1m\e[32m execute (1.2ms)\e[0m \e[2m{query: {match_all: {}}}\e[0m")
+        subject
+      end
+    end
+  end
+end

--- a/elasticsearch-rails/spec/spec_helper.rb
+++ b/elasticsearch-rails/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'active_record'
 require 'elasticsearch/model'
 require 'elasticsearch/rails'
 require 'rails/railtie'
+require 'rails/version'
 require 'elasticsearch/rails/instrumentation'
 
 


### PR DESCRIPTION
This is backport(cherry-picked) of https://github.com/elastic/elasticsearch-rails/pull/1067 to `7.x` branch