### PR TITLE
Fix ArgumentError when calling dup on aggregations

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
@@ -22,7 +22,7 @@ module Elasticsearch
       class Aggregations < HashWrapper
         disable_warnings if respond_to?(:disable_warnings)
 
-        def initialize(attributes={})
+        def initialize(attributes={}, options= {})
           __redefine_enumerable_methods super(attributes)
         end
 

--- a/elasticsearch-model/spec/elasticsearch/model/response/aggregations_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/aggregations_spec.rb
@@ -80,4 +80,11 @@ describe Elasticsearch::Model::Response::Aggregations do
       expect(aggregations.price.max.value).to eq(99)
     end
   end
+
+  describe '#dup' do
+
+    it 'creates a copy of the aggregation' do
+      expect(aggregations.dup).to eq(aggregations)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an issue where calling .dup on aggregations in elasticsearch-rails results in the following error:

ArgumentError Exception: wrong number of arguments (given 2, expected 0..1)
Testing
Verified that .dup now works correctly on aggregations.
Ensured no breaking changes in existing functionality.