### PR TITLE
Fix Elasticsearch::Model::Response#dup

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/response/aggregations.rb
@@ -26,6 +26,11 @@ module Elasticsearch
           __redefine_enumerable_methods super(attributes)
         end
 
+        # #initialize takes fewer arguments than the ::Hashie::Mash superclass so we have to change dup accordingly
+        def dup
+          self.class.new(self)
+        end
+
         # Fix the problem of Hashie::Mash returning unexpected values for `min` and `max` methods
         #
         # People can define names for aggregations such as `min` and `max`, but these

--- a/elasticsearch-model/spec/elasticsearch/model/response/aggregations_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/response/aggregations_spec.rb
@@ -80,4 +80,15 @@ describe Elasticsearch::Model::Response::Aggregations do
       expect(aggregations.price.max.value).to eq(99)
     end
   end
+
+  describe '#dup' do
+
+    it 'creates a duplicate of the aggregations object' do
+      duped_aggregations = aggregations.dup
+      expect(duped_aggregations).to be_a(Elasticsearch::Model::Response::Aggregations)
+      expect(duped_aggregations).not_to be(aggregations)
+      expect(duped_aggregations.foo.bar).to eq(10)
+      expect(duped_aggregations.price.doc_count).to eq(123)
+    end
+  end
 end


### PR DESCRIPTION
`::Hashie::Mash` overrides `#dup`; it calls `.new` and thus also `#initialize`. The implementation doesn't work for `Elasticsearch::Model::Response` since its initialize method takes fewer arguments than `::Hashie::Mash`. This fixes that.